### PR TITLE
Internal refactoring on opus encoding/decoding in the portaudio callback

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,25 @@
 # content moved from README.md
 
+## latency-work
+
+### test-duplex.js
+
+During switching of apps / stress testing, occurences of:
+
+- [PoaOutput]: _HandlePaStreamCallback: SKIPPING frames/partial playback, only (24) available intermediate frames
+- [PoaOutput]: FAILED PaUtil_WriteRingBuffer rIntermediateCallbackBuf at expected sequenceNumber(3113)
+
+### tryout
+
+This does fully C++ based input/output (not sending the data through the js stack for monitoring)
+(perhaps for local monitoring, the input/output handling needs to be done through C++ only)
+
+### rtp receiver
+
+TODO: test if rtp receiver only playback also has [PoaOutput] issues.
+
+## old content
+
 (this might not be fully accurate atm)
 
 NOTE: Work in progress

--- a/doc/input_encoding.md
+++ b/doc/input_encoding.md
@@ -50,6 +50,8 @@ The `EncodeWorker` will perform the actual opus encoding of the data from the Ri
 - [opus_defines.h](https://www.opus-codec.org/docs/html_api-1.1.0/opus__defines_8h.html) contains additional interesting items:
   - `OPUS_SET_GAIN_REQUEST`  Scales the decoded output by a factor specified in Q8 dB units. This has a maximum range of -32768 to 32767 inclusive
 
+- `opus_encode` `max_packet` is the maximum number of bytes that can be written in the packet (4000 bytes is recommended)
+
 ## Opus Questions
 
 - default bitrate? based on numbers of channels and input sampling rate

--- a/doc/input_encoding.md
+++ b/doc/input_encoding.md
@@ -1,0 +1,79 @@
+# Input Encoding Information
+
+## PortAudio
+
+The `paStaticInputCallback` method is registered with PortAudio and will call the relevant `paEncodeInStream::paInputCallback`.
+
+The `paInputCallback` will write input frames into a PortAudio RingBuffer to try and decouple the callback from the rest of the handling.
+
+The opus codec requires chunks of 120 frames to be able to work.
+Currently, this means that when 120 frames are available in the RingBuffer, a callback is run to indicate `OpusFrameAvailable`.
+This callback must be registered with `paEncodeInStream::setUserCallbackOpusFrameAvailable`.
+
+The `Rehearse20` class will register the static `paEncodeInStreamOpusFrameAvailableCallback` function which in turn calls `Rehearse20::handleEncodeInStreamCallback` to handle.
+
+`handleEncodeInStreamCallback` will perform a `tsfn.NonBlockingCall` will ensure on the main js code will be executed.
+
+On the main js thread the static `Rehearse20::JsThreadHandleEncodeInStreamCallback` will be called, which in turn calls `Rehearse20::handleEncodeInStreamCallback` to start an `EncodeWorker`.
+
+The `EncodeWorker` will perform the actual opus encoding of the data from the RingBuffer using the `paEncodeInStream::EncodeRecordingIntoData` method.
+
+## Ideas
+
+- On paInputCallback perform the actual opus encoding and put the compressed data into the RingBuffer
+  This requires less data in the RingBuffer at a trade off for spending more cpu time on the audio thread.
+
+- EncodeWorker currently only handles one opus frame at a time (causing `EncodeWorker::Execute could do (x) more opus encodings`).
+  
+## Opus Notes
+
+- [OPUS_APPLICATION_RESTRICTED_LOWDELAY](https://www.opus-codec.org/docs/opus_api-1.2/group__opus__encoder.html#gaa89264fd93c9da70362a0c9b96b9ca88) configures low-delay mode that disables the speech-optimized mode in exchange for slightly reduced delay.
+  This mode can only be set on an newly initialized or freshly reset encoder because it changes the codec delay.
+  Only use when lowest-achievable latency is what matters most.
+  Voice-optimized modes cannot be used.
+
+- DTX disabled by default (only relevant for LPC layer)
+- FEC disabled by default (only relevant for LPC layer)
+- OPUS_BANDWIDTH_FULLBAND (20kHz passband) by default or OPUS_AUTO?
+- OPUS_AUTO signal by default
+- VBR enabled by default
+- Constrained VBR by default
+
+- Opus is a stateful codec with overlapping blocks and as a result Opus packets are not coded independently of each other. Packets must be passed into the decoder serially and in the correct order for a correct decode. Lost packets can be replaced with loss concealment by calling the decoder with a null pointer and zero length for the missing packet.
+
+- `opus_decode` `frame_size` Number of samples per channel of available space in pcm. If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will not be capable of decoding some packets.
+
+- `opus_decode` In the case of PLC (data==NULL) or FEC (decode_fec=1), then frame_size needs to be exactly the duration of audio that is missing, otherwise the decoder will not be in the optimal state to decode the next incoming packet.
+
+- `opus_decoder_create` Internally Opus stores data at 48000 Hz, so that should be the default value for Fs. However, the decoder can efficiently decode to buffers at 8, 12, 16, and 24 kHz so if for some reason the caller cannot use data at the full sample rate, or knows the compressed data doesn't use the full frequency range, it can request decoding at a reduced rate. Likewise, the decoder is capable of filling in either mono or interleaved stereo pcm buffers, at the caller's request.
+
+- [opus_defines.h](https://www.opus-codec.org/docs/html_api-1.1.0/opus__defines_8h.html) contains additional interesting items:
+  - `OPUS_SET_GAIN_REQUEST`  Scales the decoded output by a factor specified in Q8 dB units. This has a maximum range of -32768 to 32767 inclusive
+
+## Opus Questions
+
+- default bitrate? based on numbers of channels and input sampling rate
+- default complexity?
+
+- use [OPUS_GET_LOOKAHEAD](https://github.com/xiph/opus/blob/4f4b11c2398e96134dc62ee794bfe33ecd6e9bd2/include/opus_defines.h#L464) to determine samples to skip from the start? (`OPUS_GET_LOOKAHEAD_REQUEST`), in case of OPUS_APPLICATION_RESTRICTED_LOWDELAY this only seems to be
+48000/400 = 120, meaning the first decoded opus_frame could be skipped for playback??
+
+    ```c
+    /** Gets the total samples of delay added by the entire codec.
+    * This can be queried by the encoder and then the provided number of samples can be
+    * skipped on from the start of the decoder's output to provide time aligned input
+    * and output. From the perspective of a decoding application the real data begins this many
+    * samples late.
+    *
+    * The decoder contribution to this delay is identical for all decoders, but the
+    * encoder portion of the delay may vary from implementation to implementation,
+    * version to version, or even depend on the encoder's initial configuration.
+    * Applications needing delay compensation should call this CTL rather than
+    * hard-coding a value.
+    * @param[out] x <tt>opus_int32 *</tt>:   Number of lookahead samples
+    * @hideinitializer */
+    #define OPUS_GET_LOOKAHEAD(x) OPUS_GET_LOOKAHEAD_REQUEST, __opus_check_int_ptr(x)
+    ```
+
+- LSB_DEPTH (default 24)? default 16 when using opus_encode (opus_int16), helps identifying silence and near-silence.
+- prediction enabled (default)?

--- a/doc/latency.md
+++ b/doc/latency.md
@@ -1,0 +1,60 @@
+# pa-opus-audio latency information
+
+## assumptions
+
+- focus on achieving low latency
+
+  - if we need to drop input data because consumer can't keep up we will actually drop data
+  - if we need to drop output data because producer can't keep up we will actually drop data
+  - opus 2.5ms@48kHz means a frame_size of 120 frames
+    - this means we need to wait for 120 frames to be available from input before start encoding
+    - this means we will receive in chunks of 120 frames
+      - playback can start at the earliest 2.5ms after recording is done
+  - portaudio provides PaStreamInfo after stream is opened
+    - inputLatency
+    - outputLatency
+  - portaudio OpenStream framesPerBuffer: the number of frames passed to the stream callback
+  - output.framesPerBuffer determines the earliest when playback can start
+
+## Example
+
+    DeviceId:         1 (Built-in Output)
+    ChannelCount:     1
+    SuggestedLatency: 0.003625
+    InputLatency:                 0.000000 (    0 samples)
+    OutputLatency:                0.003625 (  174 samples)
+    SampleRate:       48000
+
+    DeviceId:         0 (Built-in Microphone)
+    ChannelCount:     1
+    SuggestedLatency: 0.002771
+    InputLatency:                 0.002771 (  133 samples)
+    OutputLatency:                0.000000 (    0 samples)
+    SampleRate:       48000
+
+    input callback wil be called at the earliest after 133 samples of recording
+
+    133: can encode one opus chunk (120 frames)
+
+    when is the callback function first called?
+    - input.framesPerBuffer < 133
+    - input.framesPerBuffer > 133
+
+## Ideas
+
+- input ringbuffer is
+  - minimal 120 opusframe
+  - ??max(160, PaStreamInfo.inputLatency) + input.framesPerBuffer?
+- input.framesPerBuffer = 64/128/256/512?
+
+input (latency 133)
+120 -> 120
+
+64 -> 64
+64 -> 128 -> -120 -> 8
+64 -> 72
+64 -> 
+
+output latency
+
+2 * opus frame ?

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -43,7 +43,7 @@ class PoaInput {
 }
 
 class PoaOutput {
-    constructor(name: string = 'PoaOutpu') {
+    constructor(name: string = 'PoaOutput') {
         this._addonInstance = new addon.Rehearse20(name)
     }
 

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -6,6 +6,7 @@ const addon = require('../build/Release/pa-opus-audio');
 interface IRehearse20Native {
     greet(strName: string): string;
     detect(): number;
+    tryout(): number;
     protoring(): number;
 
     OutputInitAndStartStream(): number;
@@ -31,11 +32,11 @@ class PoaInput {
         return this._addonInstance.InputInitAndStartStream();
     }
 
-    stopRecord():number {
+    stopRecord(): number {
         return this._addonInstance.InputStopStream();
     }
 
-    setEncodedFrameAvailableCallback(cb:Function): number {
+    setEncodedFrameAvailableCallback(cb: Function): number {
         return this._addonInstance.SetEncodedFrameAvailableCallBack(cb);
     }
 
@@ -56,7 +57,7 @@ class PoaOutput {
         return this._addonInstance.OutputStopStream();
     }
 
-    decodeAndPlay(data:Buffer): number {
+    decodeAndPlay(data: Buffer): number {
         return this._addonInstance.DecodeDataIntoPlayback(data);
     }
 
@@ -91,17 +92,21 @@ class PoaExperimental {
         return this._addonInstance.detect();
     }
 
+    tryout(): number {
+        return this._addonInstance.tryout();
+    }
+
     /**
      * 
      */
-    protoring():number {
+    protoring(): number {
         return this._addonInstance.protoring();
     }
 
     /**
      * 
      */
-    OutputInitAndStartStream():number {
+    OutputInitAndStartStream(): number {
         return this._addonInstance.OutputInitAndStartStream();
     }
 
@@ -109,14 +114,14 @@ class PoaExperimental {
      * Playback audio by decoding previously encoded data
      * @param data Buffer to be decoded into playback
      */
-    DecodeDataIntoPlayback(data: Buffer):number {
+    DecodeDataIntoPlayback(data: Buffer): number {
         return this._addonInstance.DecodeDataIntoPlayback(data);
     }
 
     /**
      * Start the input stream
      */
-    InputInitAndStartStream():number {
+    InputInitAndStartStream(): number {
         return this._addonInstance.InputInitAndStartStream();
     }
 
@@ -128,7 +133,7 @@ class PoaExperimental {
      * Setup callback for receiving encoded data that was recorded
      * @param cb callback for receiving encoded data
      */
-    SetEncodedFrameAvailableCallBack(cb: Function):number {
+    SetEncodedFrameAvailableCallBack(cb: Function): number {
         return this._addonInstance.SetEncodedFrameAvailableCallBack(cb);
     }
 
@@ -137,7 +142,7 @@ class PoaExperimental {
 }
 
 //export = Rehearse20;
-export { 
+export {
     PoaInput,
     PoaOutput,
     PoaExperimental

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -1,7 +1,5 @@
-const addon = require('../build/Release/pa-opus-audio');
+const addon = require('bindings')('pa-opus-audio');
 
-//use this for debug builds with meaningfull stack trace symbols 
-//const addon = require('../build/Debug/pa-opus-audio');
 
 interface IRehearse20Native {
     greet(strName: string): string;

--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -22,8 +22,8 @@ interface IRehearse20Native {
  * 
  */
 class PoaInput {
-    constructor() {
-        this._addonInstance = new addon.Rehearse20("PoaInput")
+    constructor(name: string = 'PoaInput') {
+        this._addonInstance = new addon.Rehearse20(name)
     }
 
     initStartRecord(): number {
@@ -43,8 +43,8 @@ class PoaInput {
 }
 
 class PoaOutput {
-    constructor() {
-        this._addonInstance = new addon.Rehearse20("PoaOutput")
+    constructor(name: string = 'PoaOutpu') {
+        this._addonInstance = new addon.Rehearse20(name)
     }
 
     initStartPlayback(): number {

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,6 +179,14 @@
                 "chainsaw": "~0.1.0"
             }
         },
+        "bindings": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+            "requires": {
+                "file-uri-to-path": "1.0.0"
+            }
+        },
         "bl": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
@@ -565,6 +573,11 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+        },
+        "file-uri-to-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
         },
         "forever-agent": {
             "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "pa-opus-audio",
-    "version": "0.1.0",
+    "version": "0.2.0-dev",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
         "preprotoring": "npm run build && tsc",
         "protoring": "node ./test/test_protoring.js",
         "preduplex": "npm run build && tsc",
-        "duplex": "node ./test/test_duplex.js"
+        "duplex": "node ./test/test_duplex.js",
+        "pretryout": "npm run build && tsc",
+        "tryout": "node ./test/tryout.js"
     },
     "main": "./lib/binding.js",
     "types": "./lib/binding.d.ts"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         ]
     },
     "dependencies": {
+        "bindings": "^1.5.0",
         "cmake-js": "japj/cmake-js#fix-mac-build",
         "node-addon-api": "3.0.0",
         "prebuild-install": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "protoring": "node ./test/test_protoring.js",
         "preduplex": "npm run build && tsc",
         "duplex": "node ./test/test_duplex.js",
-        "pretryout": "npm run build && tsc",
+        "pretryout": "npm run builddebug && tsc",
         "tryout": "node ./test/tryout.js"
     },
     "main": "./lib/binding.js",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
         "pretest": "tsc",
         "test": "node ./test/test_binding.js",
         "preprotoring": "npm run build && tsc",
-        "protoring": "node ./test/test_protoring.js"
+        "protoring": "node ./test/test_protoring.js",
+        "preduplex": "npm run build && tsc",
+        "duplex": "node ./test/test_duplex.js"
     },
     "main": "./lib/binding.js",
     "types": "./lib/binding.d.ts"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "pa-opus-audio",
     "description": "pa-opus-audio is a Node.js native addon for low latency PortAudio/Opus Audio Recording and Playback.",
-    "version": "0.1.0",
+    "version": "0.2.0-dev",
     "author": "Jeroen Janssen <jeroen.janssen@gmail.com>",
     "license": "MIT",
     "keywords": [

--- a/src/DecodeWorker.cpp
+++ b/src/DecodeWorker.cpp
@@ -1,0 +1,18 @@
+#include "DecodeWorker.h"
+
+DecodeWorker::DecodeWorker(Napi::Env env, Napi::Buffer<uint8_t> buffer, paDecodeOutStream *output)
+    : Napi::AsyncWorker(env), output(output)
+{
+    length = buffer.Length();
+    data = (uint8_t *)malloc(length);
+    memcpy(data, buffer.Data(), length);
+}
+
+void DecodeWorker::Execute()
+{
+    if (data)
+    {
+        int result = output->DecodeDataIntoPlayback(data, length);
+    }
+    // TODO error handling for this?
+}

--- a/src/DecodeWorker.h
+++ b/src/DecodeWorker.h
@@ -1,0 +1,21 @@
+#ifndef DECODE_WORKER
+#define DECODE_WORKER
+
+#include <napi.h>
+
+#include "paDecodeOutStream.h"
+
+class DecodeWorker : public Napi::AsyncWorker
+{
+public:
+    DecodeWorker(Napi::Env env, Napi::Buffer<uint8_t> buffer, paDecodeOutStream *output);
+
+    void Execute() override;
+
+private:
+    uint8_t *data;
+    size_t length;
+    paDecodeOutStream *output;
+};
+
+#endif

--- a/src/EncodeWorker.cpp
+++ b/src/EncodeWorker.cpp
@@ -6,15 +6,16 @@ EncodeWorker::EncodeWorker(Napi::Function &callback, paEncodeInStream *input) : 
 
 void EncodeWorker::Execute()
 {
-    int opusFullFramesReadAvailable = input->GetOpusFullFramesReadAvailable();
-    if (opusFullFramesReadAvailable > 1)
-    {
-        printf("EncodeWorker::Execute could do (%d) more opus encodings\n", opusFullFramesReadAvailable);
-    }
     int encodeBufferSize = input->GetUncompressedBufferSizeBytes();
     this->data = (uint8_t *)malloc(encodeBufferSize);
 
     this->encoded_size = input->EncodeRecordingIntoData(this->data, encodeBufferSize);
+
+    int opusFullFramesReadAvailable = input->GetOpusFullFramesReadAvailable();
+    if (opusFullFramesReadAvailable > 0)
+    {
+        printf("EncodeWorker::Execute could do (%d) more opus encodings after already done encoding\n", opusFullFramesReadAvailable);
+    }
 }
 
 void EncodeWorker::OnOK()

--- a/src/EncodeWorker.cpp
+++ b/src/EncodeWorker.cpp
@@ -6,6 +6,11 @@ EncodeWorker::EncodeWorker(Napi::Function &callback, paEncodeInStream *input) : 
 
 void EncodeWorker::Execute()
 {
+    int opusFullFramesReadAvailable = input->GetOpusFullFramesReadAvailable();
+    if (opusFullFramesReadAvailable > 1)
+    {
+        printf("EncodeWorker::Execute could do (%d) more opus encodings\n", opusFullFramesReadAvailable);
+    }
     int encodeBufferSize = input->GetUncompressedBufferSizeBytes();
     this->data = (uint8_t *)malloc(encodeBufferSize);
 

--- a/src/EncodeWorker.cpp
+++ b/src/EncodeWorker.cpp
@@ -1,0 +1,37 @@
+#include "EncodeWorker.h"
+
+EncodeWorker::EncodeWorker(Napi::Function &callback, paEncodeInStream *input) : Napi::AsyncWorker(callback), input(input), data(0), encoded_size(0)
+{
+}
+
+void EncodeWorker::Execute()
+{
+    int encodeBufferSize = input->GetUncompressedBufferSizeBytes();
+    this->data = (uint8_t *)malloc(encodeBufferSize);
+
+    this->encoded_size = input->EncodeRecordingIntoData(this->data, encodeBufferSize);
+}
+
+void EncodeWorker::OnOK()
+{
+    if (encoded_size > 0)
+    {
+        Napi::Buffer<uint8_t> buffer = Napi::Buffer<uint8_t>::Copy(Env(), this->data, encoded_size);
+
+        Callback().Call({buffer});
+    }
+    else
+    {
+        Callback().Call({Env().Null()});
+    }
+}
+
+void EncodeWorker::Destroy()
+{
+    if (this->data)
+    {
+        free(this->data);
+        this->data = NULL;
+        this->encoded_size = 0;
+    }
+}

--- a/src/EncodeWorker.h
+++ b/src/EncodeWorker.h
@@ -1,0 +1,25 @@
+#ifndef ENCODE_WORKER
+#define ENCODE_WORKER
+
+#include <napi.h>
+
+#include "paEncodeInStream.h"
+
+class EncodeWorker : public Napi::AsyncWorker
+{
+public:
+    EncodeWorker(Napi::Function &callback, paEncodeInStream *output);
+
+    void Execute() override;
+
+    void OnOK() override;
+
+    void Destroy() override;
+
+private:
+    uint8_t *data;
+    size_t encoded_size;
+    paEncodeInStream *input;
+};
+
+#endif

--- a/src/paDecodeOutStream.cpp
+++ b/src/paDecodeOutStream.cpp
@@ -250,7 +250,7 @@ int paDecodeOutStream::InitForDevice(PaDeviceIndex device)
 
 int paDecodeOutStream::DecodeDataIntoPlayback(void *data, opus_int32 len, int dec)
 {
-    // guard against possible multiple DecodeWorkers acting
+    // guard against possible multiple DecodeWorkers interacting
     std::lock_guard<std::mutex> guard(decodeDataIntoPlaybackMutex);
 
     void *writeBufferPtr;
@@ -259,7 +259,6 @@ int paDecodeOutStream::DecodeDataIntoPlayback(void *data, opus_int32 len, int de
 
     if (sampleRate == 48000)
     {
-
 
         writeBufferPtr = this->opusDecodeBuffer;
 

--- a/src/paDecodeOutStream.cpp
+++ b/src/paDecodeOutStream.cpp
@@ -105,7 +105,7 @@ int paDecodeOutStream::paOutputCallback(
     {
         if (firstDecodeCalled)
         {
-            printf("paOutputCallback: partial read(%ld), needed(%ld)\n", actualFramesRead, framesPerBuffer);
+            printf("paOutputCallback: partial read(%d), needed(%ld)\n", actualFramesRead, framesPerBuffer);
         }
     }
 
@@ -322,7 +322,7 @@ int paDecodeOutStream::DecodeDataIntoPlayback(void *data, opus_int32 len, int de
     }
     if (framesWritten != toWriteFrameCount)
     {
-        printf("DecodeDataIntoPlayback: writeRingBuffer tried(%d) actual(%ld)\n", toWriteFrameCount, framesWritten);
+        printf("DecodeDataIntoPlayback: writeRingBuffer tried(%d) actual(%d)\n", toWriteFrameCount, framesWritten);
     }
     if (framesWritten != decodedFrameCount)
     {

--- a/src/paDecodeOutStream.cpp
+++ b/src/paDecodeOutStream.cpp
@@ -105,7 +105,7 @@ int paDecodeOutStream::paOutputCallback(
     {
         if (firstDecodeCalled)
         {
-            printf("paOutputCallback: partial read(%d), needed(%ld)\n", actualFramesRead, framesPerBuffer);
+            printf("paOutputCallback: partial read(%ld), needed(%ld)\n", actualFramesRead, framesPerBuffer);
         }
     }
 
@@ -322,7 +322,7 @@ int paDecodeOutStream::DecodeDataIntoPlayback(void *data, opus_int32 len, int de
     }
     if (framesWritten != toWriteFrameCount)
     {
-        printf("DecodeDataIntoPlayback: writeRingBuffer tried(%d) actual(%d)\n", toWriteFrameCount, framesWritten);
+        printf("DecodeDataIntoPlayback: writeRingBuffer tried(%d) actual(%ld)\n", toWriteFrameCount, framesWritten);
     }
     if (framesWritten != decodedFrameCount)
     {

--- a/src/paDecodeOutStream.cpp
+++ b/src/paDecodeOutStream.cpp
@@ -91,13 +91,17 @@ int paDecodeOutStream::paOutputCallback(
     unsigned long toCopyData = (framesPerBuffer > availableInReadBuffer) ? availableInReadBuffer : framesPerBuffer;
     if (toCopyData > 0)
     {
-        actualFramesRead = PaUtil_ReadRingBuffer(&this->rBufToRT, outputBuffer, framesPerBuffer);
+        actualFramesRead = PaUtil_ReadRingBuffer(&this->rBufToRT, outputBuffer, toCopyData);
 
         // if actualFramesRead < framesPerBuffer then we read not enough data
     }
     else
     {
         printf("paOutputCallback: not enough data available needed(%ld), available(%ld)\n", framesPerBuffer, availableInReadBuffer);
+    }
+    if (actualFramesRead != framesPerBuffer)
+    {
+        printf("paOutputCallback: partial read(%d), needed(%ld)\n", actualFramesRead, framesPerBuffer);
     }
 
     // TODO: if framesPerBuffer > availableInReadBuffer we have a buffer underrun, notify?

--- a/src/paDecodeOutStream.h
+++ b/src/paDecodeOutStream.h
@@ -41,6 +41,8 @@ private:
     //unsigned int channels; already as part of decoder needed data;
 
     PaStreamParameters outputParameters;
+    // don't log missing audio data before decoding has started
+    bool firstDecodeCalled;
     /* */
 
 public:

--- a/src/paDecodeOutStream.h
+++ b/src/paDecodeOutStream.h
@@ -2,6 +2,7 @@
 #define _PA_DECODE_OUT_STREAM
 
 #include "paStreamCommon.h"
+#include <mutex>
 
 class paDecodeOutStream
 {
@@ -13,6 +14,7 @@ private:
     void *rBufToRTData;
     /* END data for playback callback*/
 
+    std::mutex decodeDataIntoPlaybackMutex;
     /* BEGIN data for playback opus decoder */
     int sampleSizeSizeBytes;
     int channels;

--- a/src/paDecodeOutStream.h
+++ b/src/paDecodeOutStream.h
@@ -19,8 +19,14 @@ private:
     int sampleSizeSizeBytes;
     int channels;
     OpusDecoder *decoder;
+    /*
+    opusMaxFrameSize notes:
+    relates to opus_decode number of samples per channel of available space in pcm. 
+    If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will not be capable of decoding some packets.
+    */
     void *opusDecodeBuffer;
     int opusMaxFrameSize;
+    int firstFramesize;
     /* END data for playback opus decoder */
 
     /* PaStream info */

--- a/src/paDecodeOutStream.h
+++ b/src/paDecodeOutStream.h
@@ -14,7 +14,7 @@ private:
     /* END data for playback callback*/
 
     /* BEGIN data for playback opus decoder */
-    int frameSizeBytes;
+    int sampleSizeSizeBytes;
     int channels;
     OpusDecoder *decoder;
     void *opusDecodeBuffer;
@@ -27,7 +27,7 @@ private:
     /* this is data that is needed for calculation of information and cannot change after opening stream*/
     unsigned int sampleRate;
     PaSampleFormat sampleFormat;
-    long bufferElements;           // = 4096; // TODO: calculate optimal ringbuffer size
+    long maxRingBufferSamples;     // = 4096; // TODO: calculate optimal ringbuffer size
     int paCallbackFramesPerBuffer; // = 64; /* since opus decodes 120 frames, this is closests to how our latency is going to be
                                    // frames per buffer for OS Audio buffer*/
     //unsigned int channels; already as part of decoder needed data;

--- a/src/paEncodeInStream.cpp
+++ b/src/paEncodeInStream.cpp
@@ -129,7 +129,7 @@ int paEncodeInStream::paInputCallback(const void *inputBuffer,
     {
         if (firstEncodeCalled)
         {
-            printf("paInputCallback: partial written(%d), needed(%ld)\n", written, framesPerBuffer);
+            printf("paInputCallback: partial written(%ld), needed(%ld)\n", written, framesPerBuffer);
         }
     }
 

--- a/src/paEncodeInStream.cpp
+++ b/src/paEncodeInStream.cpp
@@ -119,7 +119,7 @@ int paEncodeInStream::paInputCallback(const void *inputBuffer,
     {
         printf("paInputCallback: not enough space in ringbuffer: needed(%ld), available(%ld)\n", framesPerBuffer, availableInWriteBuffer);
     }
-    if (written != framesPerBuffer)
+    if (written > 0 && written != framesPerBuffer)
     {
         printf("paInputCallback: partial written(%d), needed(%ld)\n", written, framesPerBuffer);
     }
@@ -169,9 +169,9 @@ PaError paEncodeInStream::ProtoOpenInputStream(PaDeviceIndex device)
 
     const PaStreamInfo *streamInfo;
     streamInfo = Pa_GetStreamInfo(stream);
-    int inputLatency = streamInfo->inputLatency * streamInfo->sampleRate * 2;
+    int inputLatency = streamInfo->inputLatency * streamInfo->sampleRate * 1;
 
-    int opusBasedLatency = 2 * opusMaxFrameSize;
+    int opusBasedLatency = 1 * opusMaxFrameSize;
     maxRingBufferSamples = (inputLatency > opusBasedLatency) ? inputLatency : opusBasedLatency;
     maxRingBufferSamples = calcSizeUpPow2(maxRingBufferSamples); // needed for PaUtil RingBuffer to work
     printf("maxRingBufferSamples: %ld\n", maxRingBufferSamples);
@@ -349,4 +349,10 @@ void paEncodeInStream::setUserCallbackOpusFrameAvailable(paEncodeInStreamOpusFra
 {
     this->userCallbackOpusFrameAvailable = cb;
     this->userDataCallbackOpusFrameAvailable = userData;
+}
+
+int paEncodeInStream::GetOpusFullFramesReadAvailable()
+{
+    int result = GetRingBufferReadAvailable() / opusMaxFrameSize;
+    return result;
 }

--- a/src/paEncodeInStream.cpp
+++ b/src/paEncodeInStream.cpp
@@ -67,7 +67,7 @@ int paEncodeInStream::InitPaInputData()
 
     if (this->sampleRate == 48000)
     {
-        // OPUS_APPLICATION_RESTRICTED_LOWDELAY configures low-delay mode that disables the speech-optimized mode in exchange for 
+        // OPUS_APPLICATION_RESTRICTED_LOWDELAY configures low-delay mode that disables the speech-optimized mode in exchange for
         // slightly reduced delay. This mode can only be set on an newly initialized or freshly reset encoder because it changes the codec delay.
         this->encoder = opus_encoder_create(this->sampleRate, this->channels, OPUS_APPLICATION_RESTRICTED_LOWDELAY,
                                             &err);
@@ -319,6 +319,11 @@ int paEncodeInStream::EncodeRecordingIntoData(void *data, opus_int32 len)
                 opusMaxFrameSize,
                 (unsigned char *)data,
                 len);
+        }
+
+        if (encodedPacketSize < 0)
+        {
+            printf("EncodeRecordingIntoData:OpusEncode failed\n");
         }
     }
     else

--- a/src/paEncodeInStream.cpp
+++ b/src/paEncodeInStream.cpp
@@ -67,6 +67,8 @@ int paEncodeInStream::InitPaInputData()
 
     if (this->sampleRate == 48000)
     {
+        // OPUS_APPLICATION_RESTRICTED_LOWDELAY configures low-delay mode that disables the speech-optimized mode in exchange for 
+        // slightly reduced delay. This mode can only be set on an newly initialized or freshly reset encoder because it changes the codec delay.
         this->encoder = opus_encoder_create(this->sampleRate, this->channels, OPUS_APPLICATION_RESTRICTED_LOWDELAY,
                                             &err);
         if (this->encoder == NULL)

--- a/src/paEncodeInStream.cpp
+++ b/src/paEncodeInStream.cpp
@@ -349,7 +349,8 @@ int paEncodeInStream::EncodeRecordingIntoData(void *data, opus_int32 len)
 
 int paEncodeInStream::GetUncompressedBufferSizeBytes()
 {
-    return this->sampleSizeSizeBytes * this->opusMaxFrameSize;
+    //max_packet is the maximum number of bytes that can be written in the packet (4000 bytes is recommended)
+    return 4000; //this->sampleSizeSizeBytes * this->opusMaxFrameSize;
 }
 
 void paEncodeInStream::setUserCallbackOpusFrameAvailable(paEncodeInStreamOpusFrameAvailableCallback cb, void *userData)

--- a/src/paEncodeInStream.h
+++ b/src/paEncodeInStream.h
@@ -62,6 +62,7 @@ public:
 
     /* TODO: some of these functions are here due to the move in progres and might not end up as part of the final API */
     int GetRingBufferReadAvailable(); // usefull for diagnostics
+    int GetOpusFullFramesReadAvailable();
 
     void setUserCallbackOpusFrameAvailable(paEncodeInStreamOpusFrameAvailableCallback cb, void *userData);
 

--- a/src/paEncodeInStream.h
+++ b/src/paEncodeInStream.h
@@ -18,6 +18,7 @@ private:
     void *rBufFromRTData;
     /* END data for record callback*/
 
+    std::mutex encodeRecordingIntoDataMutex;
     /* BEGIN data for record opus encoder */
     int sampleSizeSizeBytes;
     int channels;

--- a/src/paEncodeInStream.h
+++ b/src/paEncodeInStream.h
@@ -38,6 +38,8 @@ private:
                                    // frames per buffer for OS Audio buffer*/
 
     PaStreamParameters inputParameters;
+    // don't log missing audio data before encoding has started
+    bool firstEncodeCalled;
     /* */
 
     paEncodeInStreamOpusFrameAvailableCallback *userCallbackOpusFrameAvailable;

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -90,6 +90,16 @@ void poaBase::logPaError(PaError err, const char *format, ...)
     log("{%s} %s", Pa_GetErrorText(err), buffer);
 }
 
+void poaBase::logOpusError(int err, const char *format, ...)
+{
+    char buffer[512];
+    va_list args;
+    va_start(args, format);
+    vsprintf(buffer, format, args);
+    va_end(args);
+    log("{%s} %s", opus_strerror(err), buffer);
+}
+
 void poaBase::log_pa_stream_info(PaStreamParameters *params)
 {
     const PaDeviceInfo *deviceInfo;

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -163,6 +163,7 @@ int poaBase::paStaticStreamCallback(const void *inputBuffer,
     {
         // ensure we know when the callback is actually running
         data->isCallbackRunning = true;
+        data->log("paStaticStreamCallback:isCallbackRunning: %d\n", data->isCallbackRunning);
     }
 
     /* call the actual handler at c++ object side */
@@ -177,6 +178,7 @@ void poaBase::paStaticStreamFinishedCallback(void *userData)
     {
         // ensure we know when the callback is actually stopped
         data->isCallbackRunning = false;
+        data->log("paStaticStreamFinishedCallback:isCallbackRunning: %d\n", data->isCallbackRunning);
     }
 
     data->_HandlePaStreamFinished();

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -1,3 +1,4 @@
+#include <stdarg.h>
 #include "poaBase.h"
 
 poaBase::poaBase(const char *name) : name(name), stream(NULL), isCallbackRunning(false)

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -16,7 +16,11 @@ poaBase::poaBase(const char *name) : name(name),
                                      rTransferDataBufData(NULL),
                                      transferDataElements(8) // TODO: determine/calculate good value
 {
-    Pa_Initialize();
+    PaError err = Pa_Initialize();
+    if (err != paNoError)
+    {
+        logPaError(err, "FAILED Pa_Initialize");
+    }
     setupDefaultDeviceData(&inputData);
     setupDefaultDeviceData(&outputData);
 }
@@ -27,7 +31,11 @@ poaBase::~poaBase()
     {
         CloseStream();
     }
-    Pa_Terminate();
+    PaError err = Pa_Terminate();
+    if (err != paNoError)
+    {
+        logPaError(err, "FAILED Pa_Terminate");
+    }
 }
 
 void poaBase::setupDefaultDeviceData(poaDeviceData *data)

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -270,14 +270,19 @@ PaError poaBase::OpenDeviceStream(PaDeviceIndex inputDevice, PaDeviceIndex outpu
         // this needs tuning or can it be calculated?
         // TODO: remove channelCount after encoding data, this is just needed to have enough space for stereo sound?
 
-        intermediateRingBufferFrames = calcSizeUpPow2(2 * inputData.opusMaxFrameSize + inputData.callbackMaxFrameSize);
+        //intermediateRingBufferFrames = calcSizeUpPow2(2 * inputData.opusMaxFrameSize);
+        intermediateRingBufferFrames = calcSizeUpPow2(1 * inputData.opusMaxFrameSize + inputData.callbackMaxFrameSize);
         intermediateRingBufferSize = intermediateRingBufferFrames * inputData.sampleSize * inputData.streamParams.channelCount;
     }
     if (outputParams)
     {
         log_pa_stream_info(outputParams);
 
-        intermediateRingBufferFrames = calcSizeUpPow2(2 * outputData.opusMaxFrameSize + outputData.callbackMaxFrameSize);
+        // NOTE: any "crackling sound" can be recognized in the
+        // logging by [output]: writeEncodedOpusFrame:FAILED to write full opusFrame, written only (112) frames
+
+        //intermediateRingBufferFrames = calcSizeUpPow2(2 * outputData.opusMaxFrameSize);
+        intermediateRingBufferFrames = calcSizeUpPow2(1 * outputData.opusMaxFrameSize + inputData.callbackMaxFrameSize);
         intermediateRingBufferSize = intermediateRingBufferFrames * outputData.sampleSize * outputData.streamParams.channelCount;
     }
 

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -1,0 +1,19 @@
+#include "poaBase.h"
+
+poaBase::poaBase(const char *name) : name(name)
+{
+}
+
+poaBase::~poaBase()
+{
+}
+
+void poaBase::log(const char *format, ...)
+{
+    char buffer[256];
+    va_list args;
+    va_start(args, format);
+    vsprintf(buffer, format, args);
+    va_end(args);
+    printf("%s: %s", name.c_str(), buffer);
+}

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -334,3 +334,8 @@ PaError poaBase::OpenDeviceStream(PaDeviceIndex inputDevice, PaDeviceIndex outpu
     PaLOGERR(err, "HandleOpenDeviceStream\n");
     return err;
 }
+
+void poaBase::setName(const char *name)
+{
+    this->name = name;
+}

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -1,11 +1,13 @@
 #include "poaBase.h"
 
-poaBase::poaBase(const char *name) : name(name)
+poaBase::poaBase(const char *name) : name(name), stream(NULL), inputDevice(paNoDevice), outputDevice(paNoDevice)
 {
+    Pa_Initialize();
 }
 
 poaBase::~poaBase()
 {
+    Pa_Terminate();
 }
 
 void poaBase::log(const char *format, ...)
@@ -15,5 +17,58 @@ void poaBase::log(const char *format, ...)
     va_start(args, format);
     vsprintf(buffer, format, args);
     va_end(args);
-    printf("%s: %s", name.c_str(), buffer);
+    printf("[%s]: %s", name.c_str(), buffer);
+}
+
+PaError poaBase::StartStream()
+{
+    return Pa_StartStream(this->stream);
+}
+
+PaError poaBase::IsStreamActive()
+{
+    return Pa_IsStreamActive(this->stream);
+}
+
+PaError poaBase::StopStream()
+{
+    return Pa_StopStream(this->stream);
+}
+
+PaError poaBase::CloseStream()
+{
+    PaError err = paNoError;
+    err = Pa_CloseStream(this->stream);
+    this->stream = NULL;
+    return err;
+}
+
+int poaBase::paStaticCallback(const void *inputBuffer,
+                              void *outputBuffer,
+                              unsigned long framesPerBuffer,
+                              const PaStreamCallbackTimeInfo *timeInfo,
+                              PaStreamCallbackFlags statusFlags,
+                              void *userData)
+{
+    poaBase *data = (poaBase *)userData;
+
+    /* call the actual handler at c++ object side */
+    return data->HandlePaCallback(inputBuffer, outputBuffer, framesPerBuffer, timeInfo, statusFlags);
+}
+
+PaError poaBase::OpenInputDeviceStream(PaDeviceIndex inputDevice)
+{
+    return OpenDeviceStream(inputDevice);
+}
+
+PaError poaBase::OpenOutputDeviceStream(PaDeviceIndex outputDevice)
+{
+    return OpenDeviceStream(paNoDevice, outputDevice);
+}
+
+PaError poaBase::OpenDeviceStream(PaDeviceIndex inputDevice, PaDeviceIndex outputDevice)
+{
+    log("inputDevice(%d), outputDevice(%d)\n", inputDevice, outputDevice);
+
+    return paNoError;
 }

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -79,6 +79,16 @@ PaError poaBase::CloseStream()
     return err;
 }
 
+const PaStreamInfo *poaBase::GetStreamInfo()
+{
+    return Pa_GetStreamInfo(this->stream);
+}
+
+double poaBase::GetStreamCpuLoad()
+{
+    return Pa_GetStreamCpuLoad(this->stream);
+}
+
 int poaBase::paStaticStreamCallback(const void *inputBuffer,
                                     void *outputBuffer,
                                     unsigned long framesPerBuffer,

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -9,6 +9,10 @@ poaBase::poaBase(const char *name) : name(name), stream(NULL), isCallbackRunning
 
 poaBase::~poaBase()
 {
+    if (this->stream)
+    {
+        CloseStream();
+    }
     Pa_Terminate();
 }
 

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -14,7 +14,7 @@ poaBase::poaBase(const char *name) : name(name),
                                      opusSequenceNumber(0),
                                      rIntermediateCallbackBufData(NULL),
                                      rTransferDataBufData(NULL),
-                                     transferDataElements(4) // TODO: determine/calculate good value
+                                     transferDataElements(8) // TODO: determine/calculate good value
 {
     Pa_Initialize();
     setupDefaultDeviceData(&inputData);

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -89,7 +89,7 @@ void poaBase::logPaError(PaError err, const char *format, ...)
     va_start(args, format);
     vsprintf(buffer, format, args);
     va_end(args);
-    log("{%s} %s", Pa_GetErrorText(err), buffer);
+    log("ERROR {%s} %s", Pa_GetErrorText(err), buffer);
 }
 
 void poaBase::logOpusError(int err, const char *format, ...)
@@ -99,7 +99,7 @@ void poaBase::logOpusError(int err, const char *format, ...)
     va_start(args, format);
     vsprintf(buffer, format, args);
     va_end(args);
-    log("{%s} %s", opus_strerror(err), buffer);
+    log("ERROR {%s} %s", opus_strerror(err), buffer);
 }
 
 void poaBase::log_pa_stream_info(PaStreamParameters *params)

--- a/src/poaBase.cpp
+++ b/src/poaBase.cpp
@@ -266,18 +266,23 @@ PaError poaBase::OpenDeviceStream(PaDeviceIndex inputDevice, PaDeviceIndex outpu
     if (inputParams)
     {
         log_pa_stream_info(inputParams);
+
+        // this needs tuning or can it be calculated?
+        // TODO: remove channelCount after encoding data, this is just needed to have enough space for stereo sound?
+
+        intermediateRingBufferFrames = calcSizeUpPow2(2 * inputData.opusMaxFrameSize + inputData.callbackMaxFrameSize);
+        intermediateRingBufferSize = intermediateRingBufferFrames * inputData.sampleSize * inputData.streamParams.channelCount;
     }
     if (outputParams)
     {
         log_pa_stream_info(outputParams);
+
+        intermediateRingBufferFrames = calcSizeUpPow2(2 * outputData.opusMaxFrameSize + outputData.callbackMaxFrameSize);
+        intermediateRingBufferSize = intermediateRingBufferFrames * outputData.sampleSize * outputData.streamParams.channelCount;
     }
 
     err = Pa_SetStreamFinishedCallback(this->stream, this->paStaticStreamFinishedCallback);
     PaLOGERR(err, "Pa_SetStreamFinishedCallback\n");
-
-    int intermediateRingBufferFrames = calcSizeUpPow2(inputData.opusMaxFrameSize + inputData.callbackMaxFrameSize);
-    // TODO: remove channelCount after encoding data, this is just needed to have enough space for stereo sound?
-    int intermediateRingBufferSize = intermediateRingBufferFrames * inputData.sampleSize * inputData.streamParams.channelCount;
 
     log("OpenDeviceStream: intermediateRingBufferFrames(%d), intermediateRingBufferSize(%d) sampleSize(%d)\n", intermediateRingBufferFrames, intermediateRingBufferSize, inputData.sampleSize);
     rIntermediateCallbackBufData = AllocateMemory(intermediateRingBufferSize);

--- a/src/poaBase.h
+++ b/src/poaBase.h
@@ -7,6 +7,25 @@
 /* our custom way of default device selection */
 #define poaDefaultDevice ((PaDeviceIndex)-2)
 
+#define PaLOGERR(r, call)        \
+    {                            \
+        if (r < 0)               \
+        {                        \
+            logPaError(r, call); \
+        }                        \
+    }
+
+/**
+ * Device Data structure holding all related device settings required for setting up PortAudio stream
+ */
+typedef struct poaDeviceData
+{
+    PaStreamParameters streamParams;
+    double sampleRate;
+    PaStreamFlags streamFlags;
+    unsigned long framesPerBuffer;
+} poaDeviceData;
+
 class poaBase
 {
 private:
@@ -28,10 +47,10 @@ private:
                                 PaStreamCallbackFlags statusFlags,
                                 void *userData);
 
-    /** current selected inputDevice */
-    PaDeviceIndex inputDevice;
-    /** current selected outputDevice */
-    PaDeviceIndex outputDevice;
+    poaDeviceData inputData;
+    poaDeviceData outputData;
+
+    void setupDefaultDeviceData(poaDeviceData *data);
 
     /** Initializes the device for streaming audio input/output
      @param inputDevice specifies the input device to be used, paNoDevice in case no input device should be used
@@ -49,6 +68,7 @@ public:
     ~poaBase();
 
     void log(const char *format, ...);
+    void logPaError(PaError err, const char *format, ...);
 
     /** Initializes the device for streaming audio input
         @param inputDevice specifies the input device to be used, paNoDevice in case no input device should be used

--- a/src/poaBase.h
+++ b/src/poaBase.h
@@ -1,6 +1,7 @@
 #ifndef PAO_BASE_H
 #define PAO_BASE_H
 
+#include <opus/opus.h>
 #include <string>
 #include "portaudio.h"
 #include "pa_ringbuffer.h"
@@ -14,6 +15,14 @@
         {                        \
             logPaError(r, call); \
         }                        \
+    }
+
+#define OpusLOGERR(r, call)        \
+    {                              \
+        if (r < 0)                 \
+        {                          \
+            logOpusError(r, call); \
+        }                          \
     }
 
 /**
@@ -104,7 +113,7 @@ protected:
     int opusSequenceNumber;
 
     // needs to overridden to provide custom setup when opening device stream
-    virtual PaError HandleOpenDeviceStream() = 0;
+    virtual int HandleOpenDeviceStream() = 0;
 
     int calcSizeUpPow2(unsigned int v);
     // from PaUtil: AllocateMemmory/FreeMemory for RingBuffers
@@ -130,6 +139,7 @@ public:
 
     void log(const char *format, ...);
     void logPaError(PaError err, const char *format, ...);
+    void logOpusError(int err, const char *format, ...);
 
     /* Determine if the stream callback is currently running
      */

--- a/src/poaBase.h
+++ b/src/poaBase.h
@@ -143,8 +143,10 @@ public:
     /** Construct poaBase.
      @param @name The name representing this object. This will be used for logging purposes. 
      */
-    poaBase(const char *name);
+    poaBase(const char *name = "default");
     ~poaBase();
+
+    void setName(const char *name);
 
     void log(const char *format, ...);
     void logPaError(PaError err, const char *format, ...);

--- a/src/poaBase.h
+++ b/src/poaBase.h
@@ -27,6 +27,7 @@ typedef struct poaDeviceData
     unsigned long callbackMaxFrameSize;
     int sampleSize; // calculated based on streamParam.sampleFormat
     int opusMaxFrameSize;
+
 } poaDeviceData;
 
 /**
@@ -116,6 +117,8 @@ protected:
     /* Ring buffer (FIFO) for "communicating" from audio callback */
     PaUtilRingBuffer rIntermediateCallbackBuf;
     void *rIntermediateCallbackBufData;
+    int intermediateRingBufferFrames; // calculated
+    int intermediateRingBufferSize;   // calculated
     /* END data for record callback*/
 
 public:

--- a/src/poaBase.h
+++ b/src/poaBase.h
@@ -2,18 +2,96 @@
 #define PAO_BASE_H
 
 #include <string>
+#include "portaudio.h"
+
+/* our custom way of default device selection */
+#define poaDefaultDevice ((PaDeviceIndex)-2)
 
 class poaBase
 {
 private:
     /* data */
     //
-    std::string name; 
+    std::string name;
+
+    /** current stream, NULL if no stream was opened yet */
+    PaStream *stream;
+
+    /* This routine will be called by the PortAudio engine when audio is needed.
+    ** It may called at interrupt level on some machines so don't do anything
+    ** that could mess up the system like calling malloc() or free().
+    */
+    static int paStaticCallback(const void *inputBuffer,
+                                void *outputBuffer,
+                                unsigned long framesPerBuffer,
+                                const PaStreamCallbackTimeInfo *timeInfo,
+                                PaStreamCallbackFlags statusFlags,
+                                void *userData);
+
+    /** current selected inputDevice */
+    PaDeviceIndex inputDevice;
+    /** current selected outputDevice */
+    PaDeviceIndex outputDevice;
+
+    /** Initializes the device for streaming audio input/output
+     @param inputDevice specifies the input device to be used, paNoDevice in case no input device should be used
+                  poaDefaultDevice in case the system default input device should be used
+     @param outputDevice  specifies the output device to be used, paNoDevice in case no output device should be used
+                  poaDefaultDevice in case the system default input device should be used
+     */
+    PaError OpenDeviceStream(PaDeviceIndex inputDevice = paNoDevice, PaDeviceIndex outputDevice = paNoDevice);
+
 public:
+    /** Construct poaBase.
+     @param @name The name representing this object. This will be used for logging purposes. 
+     */
     poaBase(const char *name);
     ~poaBase();
 
-    void log(const char * format, ...);
+    void log(const char *format, ...);
+
+    /** Initializes the device for streaming audio input
+        @param inputDevice specifies the input device to be used, paNoDevice in case no input device should be used
+                  poaDefaultDevice in case the system default input device should be used
+     */
+    PaError OpenInputDeviceStream(PaDeviceIndex inputDevice = poaDefaultDevice);
+
+    /** Initializes the device for streaming audio output
+        @param inputDevice specifies the input device to be used, paNoDevice in case no input device should be used
+                  poaDefaultDevice in case the system default input device should be used
+     */
+    PaError OpenOutputDeviceStream(PaDeviceIndex output = poaDefaultDevice);
+
+    /**
+     * Generic PortAudio Related functions
+     */
+
+    /** Commences audio processing.
+    */
+    PaError StartStream();
+
+    /** Determine whether the stream is active.
+     */
+    PaError IsStreamActive();
+
+    /** Terminates audio processing. It waits until all pending
+     audio buffers have been played before it returns.
+    */
+    PaError StopStream();
+
+    /** Closes an audio stream. If the audio stream is active it
+     discards any pending buffers as if Pa_AbortStream() had been called.
+    */
+    PaError CloseStream();
+
+    /* called by low level callback , this needs to be public else it can't access it
+       and it needs to be overridden by actual implementation 
+    */
+    virtual int HandlePaCallback(const void *inputBuffer,
+                                 void *outputBuffer,
+                                 unsigned long framesPerBuffer,
+                                 const PaStreamCallbackTimeInfo *timeInfo,
+                                 PaStreamCallbackFlags statusFlags) = 0;
 };
 
 #endif

--- a/src/poaBase.h
+++ b/src/poaBase.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include "portaudio.h"
+#include "pa_ringbuffer.h"
 
 /* our custom way of default device selection */
 #define poaDefaultDevice ((PaDeviceIndex)-2)
@@ -110,6 +111,12 @@ protected:
     void FreeMemory(void *block);
 
     void log_pa_stream_info(PaStreamParameters *params);
+
+    /* BEGIN data for record callback*/
+    /* Ring buffer (FIFO) for "communicating" from audio callback */
+    PaUtilRingBuffer rIntermediateCallbackBuf;
+    void *rIntermediateCallbackBufData;
+    /* END data for record callback*/
 
 public:
     /** Construct poaBase.

--- a/src/poaBase.h
+++ b/src/poaBase.h
@@ -129,6 +129,18 @@ public:
     */
     PaError CloseStream();
 
+    /** Retrieve a pointer to a PaStreamInfo structure containing information
+     about the specified stream.
+    */
+    const PaStreamInfo *GetStreamInfo();
+
+    /** Retrieve CPU usage information for the specified stream.
+     The "CPU Load" is a fraction of total CPU time consumed by a callback stream's
+    audio processing routines including, but not limited to the client supplied
+    stream callback. This function does not work with blocking read/write streams.
+    */
+    double GetStreamCpuLoad();
+
     /* called by low level paStaticStreamCallback , this needs to be public else it can't access it
        and it needs to be overridden by actual implementation 
     */

--- a/src/poaBase.h
+++ b/src/poaBase.h
@@ -1,0 +1,19 @@
+#ifndef PAO_BASE_H
+#define PAO_BASE_H
+
+#include <string>
+
+class poaBase
+{
+private:
+    /* data */
+    //
+    std::string name; 
+public:
+    poaBase(const char *name);
+    ~poaBase();
+
+    void log(const char * format, ...);
+};
+
+#endif

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -89,7 +89,7 @@ bool poaDecodeOutput::writeEncodedOpusFrame(poaCallbackTransferData *data)
 
     if (!IsCallbackRunning())
     {
-        log("poaDecodeOutput::writeEncodedOpusFrame CALLBACK is not running yet, not writing data to rTransferDataBuf yet");
+        log("poaDecodeOutput::writeEncodedOpusFrame CALLBACK is not running yet, not writing data to rTransferDataBuf yet\n");
         return writtenOpusFrame;
     }
 

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -8,11 +8,13 @@ poaDecodeOutput::~poaDecodeOutput()
 {
 }
 
-int poaDecodeOutput::HandlePaCallback(const void *inputBuffer,
-                                      void *outputBuffer,
-                                      unsigned long framesPerBuffer,
-                                      const PaStreamCallbackTimeInfo *timeInfo,
-                                      PaStreamCallbackFlags statusFlags)
+int poaDecodeOutput::HandlePaStreamCallback(const void *inputBuffer,
+                                            void *outputBuffer,
+                                            unsigned long framesPerBuffer,
+                                            const PaStreamCallbackTimeInfo *timeInfo,
+                                            PaStreamCallbackFlags statusFlags)
 {
+    /* Reset output data first */
+    memset(outputBuffer, 0, framesPerBuffer * this->outputData.streamParams.channelCount * this->outputData.sampleSize);
     return paContinue;
 }

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -87,6 +87,12 @@ bool poaDecodeOutput::writeEncodedOpusFrame(poaCallbackTransferData *data)
 {
     bool writtenOpusFrame = false;
 
+    if (!IsCallbackRunning())
+    {
+        log("poaDecodeOutput::writeEncodedOpusFrame CALLBACK is not running yet, not writing data to rTransferDataBuf yet");
+        return writtenOpusFrame;
+    }
+
     ring_buffer_size_t write = PaUtil_WriteRingBuffer(&rTransferDataBuf, data, 1);
     if (write != 1)
     {

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "poaDecodeOutput.h"
 
 poaDecodeOutput::poaDecodeOutput(const char *name) : poaBase(name)

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -3,19 +3,26 @@
 
 poaDecodeOutput::poaDecodeOutput(const char *name) : poaBase(name)
 {
+    //is this needed? outputData.streamParams.channelCount = 2;
 }
 
 poaDecodeOutput::~poaDecodeOutput()
 {
 }
 
-int poaDecodeOutput::HandlePaStreamCallback(const void *inputBuffer,
-                                            void *outputBuffer,
-                                            unsigned long framesPerBuffer,
-                                            const PaStreamCallbackTimeInfo *timeInfo,
-                                            PaStreamCallbackFlags statusFlags)
+int poaDecodeOutput::_HandlePaStreamCallback(const void *inputBuffer,
+                                             void *outputBuffer,
+                                             unsigned long framesPerBuffer,
+                                             const PaStreamCallbackTimeInfo *timeInfo,
+                                             PaStreamCallbackFlags statusFlags)
 {
     /* Reset output data first */
     memset(outputBuffer, 0, framesPerBuffer * this->outputData.streamParams.channelCount * this->outputData.sampleSize);
     return paContinue;
+}
+
+PaError poaDecodeOutput::HandleOpenDeviceStream()
+{
+
+    return paNoError;
 }

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -7,3 +7,12 @@ poaDecodeOutput::poaDecodeOutput(const char *name) : poaBase(name)
 poaDecodeOutput::~poaDecodeOutput()
 {
 }
+
+int poaDecodeOutput::HandlePaCallback(const void *inputBuffer,
+                                      void *outputBuffer,
+                                      unsigned long framesPerBuffer,
+                                      const PaStreamCallbackTimeInfo *timeInfo,
+                                      PaStreamCallbackFlags statusFlags)
+{
+    return paContinue;
+}

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -43,6 +43,7 @@ int poaDecodeOutput::_HandlePaStreamCallback(const void *inputBuffer,
     {
         // only log this if encounter buffering issues after WriteEncodedOpusDataFrame has started
         log("_HandlePaStreamCallback: SKIPPING frames/partial playback, only (%d) available intermediate frames\n", toReadFrames);
+        // TODO: think about skipping incoming frames until insync with sequenceNumber/playback time
     }
 
     ring_buffer_size_t read;

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -81,41 +81,6 @@ int poaDecodeOutput::HandleOpenDeviceStream()
 
     return paNoError;
 }
-/*
-bool poaDecodeOutput::writeEncodedOpusFrame( void *data, int data_length)
-{
-    bool writtenOpusFrame = false;
-    if (!isWriteEncodedOpusFrameCalled)
-    {
-        isWriteEncodedOpusFrameCalled = true;
-    }
-
-    if (data_length != outputData.opusMaxFrameSize * outputData.sampleSize)
-    {
-        log("writeEncodedOpusFrame: buffer_size != opusMaxFrameSizeInBytes\n");
-        // atm we no uncoded data, so buffer sizes need to match
-        return writtenOpusFrame;
-    }
-    //int availableFrames = data_length / outputData.sampleSize;
-
-    ring_buffer_size_t dataAvailableFrames = data_length / outputData.sampleSize;
-
-    ring_buffer_size_t write_available;
-    write_available = PaUtil_GetRingBufferWriteAvailable(&rIntermediateCallbackBuf);
-
-    ring_buffer_size_t toWrite = dataAvailableFrames > write_available ? write_available : dataAvailableFrames;
-
-    ring_buffer_size_t written = PaUtil_WriteRingBuffer(&rIntermediateCallbackBuf, data, toWrite);
-    writtenOpusFrame = (written == dataAvailableFrames);
-    if (!writtenOpusFrame)
-    {
-        log("writeEncodedOpusFrame:FAILED to write full opusFrame, written only (%d) frames\n", written);
-        log("this is usually an indication that wrong device settings are causing low latency to fail (you might hear a 'crackling' audio sound)\n");
-    }
-    return writtenOpusFrame;
-}
-
-*/
 
 bool poaDecodeOutput::writeEncodedOpusFrame(poaCallbackTransferData *data)
 {

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -5,7 +5,8 @@ poaDecodeOutput::poaDecodeOutput(const char *name) : poaBase(name),
                                                      isWriteEncodedOpusFrameCalled(false),
                                                      decoder(NULL),
                                                      opusDecodeBuffer(NULL),
-                                                     opusDecodeBufferSize(0)
+                                                     opusDecodeBufferSize(0),
+                                                     decoderSequenceNumber(0)
 {
     //is this needed? outputData.streamParams.channelCount = 2;
 }
@@ -89,7 +90,9 @@ bool poaDecodeOutput::writeEncodedOpusFrame(poaCallbackTransferData *data)
     ring_buffer_size_t write = PaUtil_WriteRingBuffer(&rTransferDataBuf, data, 1);
     if (write != 1)
     {
-        log("poaDecodeOutput::writeEncodedOpusFrame failed to write data to rTransferDataBuf for sequence_number(%d)\n", data->sequenceNumber);
+        log("poaDecodeOutput::writeEncodedOpusFrame FAILED to write data to rTransferDataBuf for decoderSequenceNumber(%5d), IsCallbackRunning: %d\n",
+            decoderSequenceNumber,
+            IsCallbackRunning());
     }
 
     if (!isWriteEncodedOpusFrameCalled)
@@ -97,6 +100,8 @@ bool poaDecodeOutput::writeEncodedOpusFrame(poaCallbackTransferData *data)
         opusSequenceNumber = data->sequenceNumber;
         isWriteEncodedOpusFrameCalled = true;
     }
+
+    decoderSequenceNumber++;
     return write == 1;
 }
 

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -83,6 +83,7 @@ bool poaDecodeOutput::writeEncodedOpusFrame(/*int &sequence_number, */ void *dat
     if (!writtenOpusFrame)
     {
         log("writeEncodedOpusFrame:FAILED to write full opusFrame, written only (%d) frames\n", written);
+        log("this is usually an indication that wrong device settings are causing low latency to fail (you might hear a 'crackling' audio sound\n");
     }
     return writtenOpusFrame;
 }

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -18,6 +18,30 @@ int poaDecodeOutput::_HandlePaStreamCallback(const void *inputBuffer,
 {
     /* Reset output data first */
     memset(outputBuffer, 0, framesPerBuffer * this->outputData.streamParams.channelCount * this->outputData.sampleSize);
+
+    // since we eventually going to decode data and transfer from compressed chunks,
+    // we will only tranfer data if it fully fits in intermediate buffer space
+    // since framesPerBuffer < opusFrameSize(120) we need to store the content of the buffer
+    // each time there is enough space in intermediate and we have encoded data available
+    // then we transfer the encoded data for consumption to tranferBuffer
+
+    // 1. if we have enough space in intermediate buffer for a decoded opus_frame, start decoding
+    //    - need to read a poaDeviceData structure
+
+    // TODO check with poaEncodeInput for consistency
+    // TODO: what to do with sequence_numbers that have skipped content?
+
+    // x. put decoded opus frame into intermediate ringbuffer
+
+    // 8. store all possible frames from intermediate ringbuffer into outputBuffer
+    // TODO: could
+    ring_buffer_size_t read_available;
+    read_available = PaUtil_GetRingBufferReadAvailable(&rIntermediateCallbackBuf);
+    unsigned long toReadFrames = framesPerBuffer > read_available ? read_available : framesPerBuffer;
+    if (toReadFrames != framesPerBuffer)
+    {
+        log("_HandlePaStreamCallback: SKIPPING playback, no room for (%d) intermediate frames\n", framesPerBuffer - read_available);
+    }
     return paContinue;
 }
 

--- a/src/poaDecodeOutput.cpp
+++ b/src/poaDecodeOutput.cpp
@@ -1,0 +1,9 @@
+#include "poaDecodeOutput.h"
+
+poaDecodeOutput::poaDecodeOutput(const char *name) : poaBase(name)
+{
+}
+
+poaDecodeOutput::~poaDecodeOutput()
+{
+}

--- a/src/poaDecodeOutput.h
+++ b/src/poaDecodeOutput.h
@@ -58,7 +58,6 @@ public:
     poaDecodeOutput(const char *name);
     ~poaDecodeOutput();
 
-    //bool writeEncodedOpusFrame(/*int &sequence_number, */ void *data, int data_length);
     bool writeEncodedOpusFrame(poaCallbackTransferData *data);
 
     virtual int _HandlePaStreamCallback(const void *inputBuffer,

--- a/src/poaDecodeOutput.h
+++ b/src/poaDecodeOutput.h
@@ -17,6 +17,8 @@ public:
     poaDecodeOutput(const char *name);
     ~poaDecodeOutput();
 
+    bool writeEncodedOpusFrame(/*int &sequence_number, */ void *data, int data_length);
+
     virtual int _HandlePaStreamCallback(const void *inputBuffer,
                                         void *outputBuffer,
                                         unsigned long framesPerBuffer,

--- a/src/poaDecodeOutput.h
+++ b/src/poaDecodeOutput.h
@@ -8,6 +8,7 @@ class poaDecodeOutput : public poaBase
 private:
     /* data */
     bool isWriteEncodedOpusFrameCalled;
+    int decoderSequenceNumber;
 
     OpusDecoder *decoder;
     void *opusDecodeBuffer;

--- a/src/poaDecodeOutput.h
+++ b/src/poaDecodeOutput.h
@@ -1,0 +1,15 @@
+#ifndef POA_DECODE_OUTPUT_H
+#define POA_DECODE_OUTPUT_H
+
+#include "poaBase.h"
+
+class poaDecodeOutput : public poaBase
+{
+private:
+    /* data */
+public:
+    poaDecodeOutput(const char *name);
+    ~poaDecodeOutput();
+};
+
+#endif

--- a/src/poaDecodeOutput.h
+++ b/src/poaDecodeOutput.h
@@ -7,6 +7,8 @@ class poaDecodeOutput : public poaBase
 {
 private:
     /* data */
+    bool isWriteEncodedOpusFrameCalled;
+
 protected:
     virtual PaError HandleOpenDeviceStream() override;
 

--- a/src/poaDecodeOutput.h
+++ b/src/poaDecodeOutput.h
@@ -14,11 +14,11 @@ public:
     poaDecodeOutput(const char *name);
     ~poaDecodeOutput();
 
-    virtual int HandlePaCallback(const void *inputBuffer,
-                                 void *outputBuffer,
-                                 unsigned long framesPerBuffer,
-                                 const PaStreamCallbackTimeInfo *timeInfo,
-                                 PaStreamCallbackFlags statusFlags);
+    virtual int HandlePaStreamCallback(const void *inputBuffer,
+                                       void *outputBuffer,
+                                       unsigned long framesPerBuffer,
+                                       const PaStreamCallbackTimeInfo *timeInfo,
+                                       PaStreamCallbackFlags statusFlags) override;
 };
 
 #endif

--- a/src/poaDecodeOutput.h
+++ b/src/poaDecodeOutput.h
@@ -8,8 +8,17 @@ class poaDecodeOutput : public poaBase
 private:
     /* data */
 public:
+    /** Construct poaDecodeOutput.
+     @param @name The name representing this object. This will be used for logging purposes. 
+     */
     poaDecodeOutput(const char *name);
     ~poaDecodeOutput();
+
+    virtual int HandlePaCallback(const void *inputBuffer,
+                                 void *outputBuffer,
+                                 unsigned long framesPerBuffer,
+                                 const PaStreamCallbackTimeInfo *timeInfo,
+                                 PaStreamCallbackFlags statusFlags);
 };
 
 #endif

--- a/src/poaDecodeOutput.h
+++ b/src/poaDecodeOutput.h
@@ -9,8 +9,47 @@ private:
     /* data */
     bool isWriteEncodedOpusFrameCalled;
 
+    OpusDecoder *decoder;
+    void *opusDecodeBuffer;
+    int opusDecodeBufferSize; //Number of samples per channel of available space in pcm.
+                              // If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will not be capable of decoding some packets.
+
+    /* Packets must be passed into the decoder serially and in the correct order for a correct decode. Lost packets can be replaced with loss concealment by calling the decoder with a null pointer and zero length for the missing packet.
+       In the case of PLC (data==NULL) or FEC (decode_fec=1), then frame_size needs to be exactly the duration of audio that is missing
+    */
+    int opusDecodeFloat(
+        const unsigned char *data,
+        opus_int32 len,
+        float *pcm,
+        int frame_size,
+        int decode_fec);
+
+    /** Decode an Opus packet
+  * @param [in] data <tt>char*</tt>: Input payload. Use a NULL pointer to indicate packet loss
+  * @param [in] len <tt>opus_int32</tt>: Number of bytes in payload*
+  * @param [out] pcm <tt>opus_int16*</tt>: Output signal (interleaved if 2 channels). length
+  *  is frame_size*channels*sizeof(opus_int16)
+  * @param [in] frame_size Number of samples per channel of available space in \a pcm.
+  *  If this is less than the maximum packet duration (120ms; 5760 for 48kHz), this function will
+  *  not be capable of decoding some packets. In the case of PLC (data==NULL) or FEC (decode_fec=1),
+  *  then frame_size needs to be exactly the duration of audio that is missing, otherwise the
+  *  decoder will not be in the optimal state to decode the next incoming packet. For the PLC and
+  *  FEC cases, frame_size <b>must</b> be a multiple of 2.5 ms.
+  * @param [in] decode_fec <tt>int</tt>: Flag (0 or 1) to request that any in-band forward error correction data be
+  *  decoded. If no such data is available, the frame is decoded as if it were lost.
+  * @returns Number of decoded samples or @ref opus_errorcodes
+  */
+    int OpusDecode(
+        const unsigned char *data,
+        opus_int32 len,
+        opus_int16 *pcm,
+        int frame_size,
+        int decode_fec);
+
+    void DecodeOpusFrameFromTransfer();
+
 protected:
-    virtual PaError HandleOpenDeviceStream() override;
+    virtual int HandleOpenDeviceStream() override;
 
 public:
     /** Construct poaDecodeOutput.
@@ -19,7 +58,8 @@ public:
     poaDecodeOutput(const char *name);
     ~poaDecodeOutput();
 
-    bool writeEncodedOpusFrame(/*int &sequence_number, */ void *data, int data_length);
+    //bool writeEncodedOpusFrame(/*int &sequence_number, */ void *data, int data_length);
+    bool writeEncodedOpusFrame(poaCallbackTransferData *data);
 
     virtual int _HandlePaStreamCallback(const void *inputBuffer,
                                         void *outputBuffer,

--- a/src/poaDecodeOutput.h
+++ b/src/poaDecodeOutput.h
@@ -7,6 +7,9 @@ class poaDecodeOutput : public poaBase
 {
 private:
     /* data */
+protected:
+    virtual PaError HandleOpenDeviceStream() override;
+
 public:
     /** Construct poaDecodeOutput.
      @param @name The name representing this object. This will be used for logging purposes. 
@@ -14,11 +17,11 @@ public:
     poaDecodeOutput(const char *name);
     ~poaDecodeOutput();
 
-    virtual int HandlePaStreamCallback(const void *inputBuffer,
-                                       void *outputBuffer,
-                                       unsigned long framesPerBuffer,
-                                       const PaStreamCallbackTimeInfo *timeInfo,
-                                       PaStreamCallbackFlags statusFlags) override;
+    virtual int _HandlePaStreamCallback(const void *inputBuffer,
+                                        void *outputBuffer,
+                                        unsigned long framesPerBuffer,
+                                        const PaStreamCallbackTimeInfo *timeInfo,
+                                        PaStreamCallbackFlags statusFlags) override;
 };
 
 #endif

--- a/src/poaEncodeInput.cpp
+++ b/src/poaEncodeInput.cpp
@@ -1,6 +1,7 @@
 #include "poaEncodeInput.h"
 
-poaEncodeInput::poaEncodeInput(const char *name) : poaBase(name)
+poaEncodeInput::poaEncodeInput(const char *name) : poaBase(name),
+                                                   userCallbackOpusFrameAvailableCb(NULL)
 {
 }
 
@@ -54,6 +55,13 @@ int poaEncodeInput::_HandlePaStreamCallback(const void *inputBuffer,
     if (read_available >= inputData.opusMaxFrameSize)
     {
         log("_HandlePaStreamCallback: %dx opusMaxFrameSize available\n", read_available / inputData.opusMaxFrameSize);
+
+        // TODO: move this to trigger with encoded data
+        if (userCallbackOpusFrameAvailableCb != NULL)
+        {
+            log("userCallbackOpusFrameAvailableCb\n");
+            userCallbackOpusFrameAvailableCb(userCallbackOpusFrameAvailableData);
+        }
     }
 
     // 2. if we have enough frames to encode, do the encoding into temp data
@@ -66,4 +74,11 @@ PaError poaEncodeInput::HandleOpenDeviceStream()
     PaError err = paNoError;
 
     return err;
+}
+
+void poaEncodeInput::registerOpusFrameAvailableCb(paEncodeInputOpusFrameAvailableCb cb, void *userData)
+{
+    log("registerOpusFrameAvailableCb\n");
+    this->userCallbackOpusFrameAvailableCb = cb;
+    this->userCallbackOpusFrameAvailableData = userData;
 }

--- a/src/poaEncodeInput.cpp
+++ b/src/poaEncodeInput.cpp
@@ -8,11 +8,11 @@ poaEncodeInput::~poaEncodeInput()
 {
 }
 
-int poaEncodeInput::HandlePaCallback(const void *inputBuffer,
-                                     void *outputBuffer,
-                                     unsigned long framesPerBuffer,
-                                     const PaStreamCallbackTimeInfo *timeInfo,
-                                     PaStreamCallbackFlags statusFlags)
+int poaEncodeInput::HandlePaStreamCallback(const void *inputBuffer,
+                                           void *outputBuffer,
+                                           unsigned long framesPerBuffer,
+                                           const PaStreamCallbackTimeInfo *timeInfo,
+                                           PaStreamCallbackFlags statusFlags)
 {
     return paContinue;
 }

--- a/src/poaEncodeInput.cpp
+++ b/src/poaEncodeInput.cpp
@@ -54,7 +54,7 @@ int poaEncodeInput::_HandlePaStreamCallback(const void *inputBuffer,
     read_available = PaUtil_GetRingBufferReadAvailable(&rIntermediateCallbackBuf);
     if (read_available >= inputData.opusMaxFrameSize)
     {
-        log("_HandlePaStreamCallback: %dx opusMaxFrameSize available\n", read_available / inputData.opusMaxFrameSize);
+        //log("_HandlePaStreamCallback: %dx opusMaxFrameSize available\n", read_available / inputData.opusMaxFrameSize);
 
         // TODO: move this to trigger with encoded data
         if (userCallbackOpusFrameAvailableCb != NULL)

--- a/src/poaEncodeInput.cpp
+++ b/src/poaEncodeInput.cpp
@@ -1,0 +1,9 @@
+#include "poaEncodeInput.h"
+
+poaEncodeInput::poaEncodeInput(const char *name) : poaBase(name)
+{
+}
+
+poaEncodeInput::~poaEncodeInput()
+{
+}

--- a/src/poaEncodeInput.cpp
+++ b/src/poaEncodeInput.cpp
@@ -100,36 +100,6 @@ void poaEncodeInput::registerOpusFrameAvailableCb(paEncodeInputOpusFrameAvailabl
     this->userCallbackOpusFrameAvailableCb = cb;
     this->userCallbackOpusFrameAvailableData = userData;
 }
-/*
-int poaEncodeInput::readUncompressedFrames(int &sequence_number, void *buffer, int buffer_size)
-{
-    int readBytes = 0;
-
-    ring_buffer_size_t read_available;
-    read_available = PaUtil_GetRingBufferReadAvailable(&rIntermediateCallbackBuf);
-    if (read_available < inputData.opusMaxFrameSize)
-    {
-        log("readEncodedOpusFrame before full opus frame is available\n");
-        return readBytes;
-    }
-
-    int neededBytes = inputData.opusMaxFrameSize * inputData.sampleSize;
-    if (buffer_size < neededBytes)
-    {
-        log("readEncodedOpusFrame buffer_size(%d) < neededBytes(%d)\n", buffer_size, neededBytes);
-        // cannot copy encoded opus frame, so don't do anything
-        return readBytes;
-    }
-
-    // TODO sequence_number
-
-    ring_buffer_size_t read = PaUtil_ReadRingBuffer(&rIntermediateCallbackBuf, buffer, inputData.opusMaxFrameSize);
-    readBytes = read * inputData.sampleSize;
-    // TODO: change this when having encoded data for now we treat
-    //readOpusFrame = (read == inputData.opusMaxFrameSize);
-    return readBytes;
-}
-*/
 
 int poaEncodeInput::opusEncodeFloat(
     const float *pcm,

--- a/src/poaEncodeInput.cpp
+++ b/src/poaEncodeInput.cpp
@@ -7,3 +7,12 @@ poaEncodeInput::poaEncodeInput(const char *name) : poaBase(name)
 poaEncodeInput::~poaEncodeInput()
 {
 }
+
+int poaEncodeInput::HandlePaCallback(const void *inputBuffer,
+                                     void *outputBuffer,
+                                     unsigned long framesPerBuffer,
+                                     const PaStreamCallbackTimeInfo *timeInfo,
+                                     PaStreamCallbackFlags statusFlags)
+{
+    return paContinue;
+}

--- a/src/poaEncodeInput.cpp
+++ b/src/poaEncodeInput.cpp
@@ -1,6 +1,6 @@
 #include "poaEncodeInput.h"
 
-poaEncodeInput::poaEncodeInput(const char *name) : poaBase(name)
+poaEncodeInput::poaEncodeInput(const char *name) : poaBase(name), rIntermediateCallbackBufData(NULL)
 {
 }
 
@@ -8,11 +8,60 @@ poaEncodeInput::~poaEncodeInput()
 {
 }
 
-int poaEncodeInput::HandlePaStreamCallback(const void *inputBuffer,
-                                           void *outputBuffer,
-                                           unsigned long framesPerBuffer,
-                                           const PaStreamCallbackTimeInfo *timeInfo,
-                                           PaStreamCallbackFlags statusFlags)
+int poaEncodeInput::_HandlePaStreamCallback(const void *inputBuffer,
+                                            void *outputBuffer,
+                                            unsigned long framesPerBuffer,
+                                            const PaStreamCallbackTimeInfo *timeInfo,
+                                            PaStreamCallbackFlags statusFlags)
 {
+    // since we eventually going to encode data and transfer in compressed chunks,
+    // we will only tranfer data if it fully fits available space
+    // since framesPerBuffer < opusFrameSize(120) we need to store the content of the buffer
+    // until we have enough opusFrameSize content to start encoding
+    // then we transfer the encoded data for consumption to tranferBuffer
+
+    // 1. store new frames in intermediate ringbuffer
+    // 2. if we have enough frames to encode, do the encoding into temp data
+    // 3. calculate size requirements for poaDeviceData structure
+    //    - if available ringbuffer size is not enough, skip writing
+    //      (but log issue)
+    // 5. increase opusSequenceNumber
+    // 6. construct poaDeviceData structure
+    // 7. put poaDeviceData into RingBuffer
+    //    - first the poaCallbackTransferData, then the actual encoded data
+    // 8. trigger opusAvailableFrame callback
+
+    ring_buffer_size_t written;
+    ring_buffer_size_t available;
+    available = PaUtil_GetRingBufferWriteAvailable(&rIntermediateCallbackBuf);
+    if (framesPerBuffer > available)
+    {
+        log("_HandlePaStreamCallback more framesPerBuffer(%ld) than available(%d)", available);
+        return paContinue;
+    }
+    written = PaUtil_WriteRingBuffer(&rIntermediateCallbackBuf, inputBuffer, framesPerBuffer);
+    if (written != framesPerBuffer)
+    {
+        log("_HandlePaStreamCallback should not happen? frames available(%ld), written(%d)", framesPerBuffer, written);
+    }
+
     return paContinue;
+}
+
+PaError poaEncodeInput::HandleOpenDeviceStream()
+{
+    // TODO: intermediateRingBuffer is probably common
+    PaError err = paNoError;
+    int intermediateRingBufferFrames = inputData.opusMaxFrameSize + inputData.callbackMaxFrameSize;
+    // TODO: remove channelCount after encoding data, this is just needed to have enough space for stereo sound?
+    int intermediateRingBufferSize = calcSizeUpPow2(intermediateRingBufferFrames * inputData.sampleSize * inputData.streamParams.channelCount);
+
+    rIntermediateCallbackBufData = AllocateMemory(intermediateRingBufferSize);
+    if (rIntermediateCallbackBufData == NULL)
+    {
+        return paInsufficientMemory;
+    }
+    err = PaUtil_InitializeRingBuffer(&rIntermediateCallbackBuf, inputData.sampleSize, intermediateRingBufferSize, rIntermediateCallbackBufData);
+
+    return err;
 }

--- a/src/poaEncodeInput.cpp
+++ b/src/poaEncodeInput.cpp
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "poaEncodeInput.h"
 
 poaEncodeInput::poaEncodeInput(const char *name) : poaBase(name),

--- a/src/poaEncodeInput.h
+++ b/src/poaEncodeInput.h
@@ -10,9 +10,56 @@ class poaEncodeInput : public poaBase
 private:
     paEncodeInputOpusFrameAvailableCb *userCallbackOpusFrameAvailableCb;
     void *userCallbackOpusFrameAvailableData;
+    OpusEncoder *encoder;
+    void *opusEncodeBuffer;
+    size_t opusEncodeBufferSize; // `max_packet` is the maximum number of bytes that can be written in the packet(4000 bytes is recommended)
+    void *opusIntermediateFrameInputBuffer;
+    size_t opusIntermediateFrameInputBufferSize;
+
+    int
+    opusEncodeFloat(
+        const float *pcm,
+        int frame_size,
+        unsigned char *data,
+        opus_int32 max_data_bytes);
+
+    /** Encodes an Opus frame.
+  * @param [in] pcm <tt>opus_int16*</tt>: Input signal (interleaved if 2 channels). length is frame_size*channels*sizeof(opus_int16)
+  * @param [in] frame_size <tt>int</tt>: Number of samples per channel in the
+  *                                      input signal.
+  *                                      This must be an Opus frame size for
+  *                                      the encoder's sampling rate.
+  *                                      For example, at 48 kHz the permitted
+  *                                      values are 120, 240, 480, 960, 1920,
+  *                                      and 2880.
+  *                                      Passing in a duration of less than
+  *                                      10 ms (480 samples at 48 kHz) will
+  *                                      prevent the encoder from using the LPC
+  *                                      or hybrid modes.
+  * @param [out] data <tt>unsigned char*</tt>: Output payload.
+  *                                            This must contain storage for at
+  *                                            least \a max_data_bytes.
+  * @param [in] max_data_bytes <tt>opus_int32</tt>: Size of the allocated
+  *                                                 memory for the output
+  *                                                 payload. This may be
+  *                                                 used to impose an upper limit on
+  *                                                 the instant bitrate, but should
+  *                                                 not be used as the only bitrate
+  *                                                 control. Use #OPUS_SET_BITRATE to
+  *                                                 control the bitrate.
+  * @returns The length of the encoded packet (in bytes) on success or a
+  *          negative error code (see @ref opus_errorcodes) on failure.
+  */
+    int OpusEncode(
+        const opus_int16 *pcm,
+        int frame_size,
+        unsigned char *data,
+        opus_int32 max_data_bytes);
+
+    void EncodeOpusFrameFromIntermediate();
 
 protected:
-    virtual PaError HandleOpenDeviceStream() override;
+    virtual int HandleOpenDeviceStream() override;
 
 public:
     /** Construct poaEncodeInput.

--- a/src/poaEncodeInput.h
+++ b/src/poaEncodeInput.h
@@ -14,11 +14,11 @@ public:
     poaEncodeInput(const char *name);
     ~poaEncodeInput();
 
-    virtual int HandlePaCallback(const void *inputBuffer,
-                                 void *outputBuffer,
-                                 unsigned long framesPerBuffer,
-                                 const PaStreamCallbackTimeInfo *timeInfo,
-                                 PaStreamCallbackFlags statusFlags);
+    virtual int HandlePaStreamCallback(const void *inputBuffer,
+                                       void *outputBuffer,
+                                       unsigned long framesPerBuffer,
+                                       const PaStreamCallbackTimeInfo *timeInfo,
+                                       PaStreamCallbackFlags statusFlags) override;
 };
 
 #endif

--- a/src/poaEncodeInput.h
+++ b/src/poaEncodeInput.h
@@ -2,11 +2,20 @@
 #define POA_ENCODE_INPUT_H
 
 #include "poaBase.h"
+#include "pa_ringbuffer.h"
 
 class poaEncodeInput : public poaBase
 {
 private:
-    /* data */
+    /* BEGIN data for record callback*/
+    /* Ring buffer (FIFO) for "communicating" from audio callback */
+    PaUtilRingBuffer rIntermediateCallbackBuf;
+    void *rIntermediateCallbackBufData;
+    /* END data for record callback*/
+
+protected:
+    virtual PaError HandleOpenDeviceStream() override;
+
 public:
     /** Construct poaEncodeInput.
      @param @name The name representing this object. This will be used for logging purposes. 
@@ -14,11 +23,11 @@ public:
     poaEncodeInput(const char *name);
     ~poaEncodeInput();
 
-    virtual int HandlePaStreamCallback(const void *inputBuffer,
-                                       void *outputBuffer,
-                                       unsigned long framesPerBuffer,
-                                       const PaStreamCallbackTimeInfo *timeInfo,
-                                       PaStreamCallbackFlags statusFlags) override;
+    virtual int _HandlePaStreamCallback(const void *inputBuffer,
+                                        void *outputBuffer,
+                                        unsigned long framesPerBuffer,
+                                        const PaStreamCallbackTimeInfo *timeInfo,
+                                        PaStreamCallbackFlags statusFlags) override;
 };
 
 #endif

--- a/src/poaEncodeInput.h
+++ b/src/poaEncodeInput.h
@@ -1,0 +1,15 @@
+#ifndef POA_ENCODE_INPUT_H
+#define POA_ENCODE_INPUT_H
+
+#include "poaBase.h"
+
+class poaEncodeInput : public poaBase
+{
+private:
+    /* data */
+public:
+    poaEncodeInput(const char *name);
+    ~poaEncodeInput();
+};
+
+#endif

--- a/src/poaEncodeInput.h
+++ b/src/poaEncodeInput.h
@@ -71,7 +71,6 @@ public:
 
     void registerOpusFrameAvailableCb(paEncodeInputOpusFrameAvailableCb cb, void *userData);
 
-    //int readUncompressedFrames(/*int &sequence_number,*/ void *buffer, int buffer_size);
     int encodedOpusFramesAvailable();
     bool readEncodedOpusFrame(poaCallbackTransferData *data);
 

--- a/src/poaEncodeInput.h
+++ b/src/poaEncodeInput.h
@@ -2,16 +2,10 @@
 #define POA_ENCODE_INPUT_H
 
 #include "poaBase.h"
-#include "pa_ringbuffer.h"
 
 class poaEncodeInput : public poaBase
 {
 private:
-    /* BEGIN data for record callback*/
-    /* Ring buffer (FIFO) for "communicating" from audio callback */
-    PaUtilRingBuffer rIntermediateCallbackBuf;
-    void *rIntermediateCallbackBufData;
-    /* END data for record callback*/
 
 protected:
     virtual PaError HandleOpenDeviceStream() override;

--- a/src/poaEncodeInput.h
+++ b/src/poaEncodeInput.h
@@ -3,9 +3,13 @@
 
 #include "poaBase.h"
 
+typedef void paEncodeInputOpusFrameAvailableCb(void *userData);
+
 class poaEncodeInput : public poaBase
 {
 private:
+    paEncodeInputOpusFrameAvailableCb *userCallbackOpusFrameAvailableCb;
+    void *userCallbackOpusFrameAvailableData;
 
 protected:
     virtual PaError HandleOpenDeviceStream() override;
@@ -16,6 +20,8 @@ public:
      */
     poaEncodeInput(const char *name);
     ~poaEncodeInput();
+
+    void registerOpusFrameAvailableCb(paEncodeInputOpusFrameAvailableCb cb, void *userData);
 
     virtual int _HandlePaStreamCallback(const void *inputBuffer,
                                         void *outputBuffer,

--- a/src/poaEncodeInput.h
+++ b/src/poaEncodeInput.h
@@ -10,6 +10,7 @@ class poaEncodeInput : public poaBase
 private:
     paEncodeInputOpusFrameAvailableCb *userCallbackOpusFrameAvailableCb;
     void *userCallbackOpusFrameAvailableData;
+
     OpusEncoder *encoder;
     void *opusEncodeBuffer;
     size_t opusEncodeBufferSize; // `max_packet` is the maximum number of bytes that can be written in the packet(4000 bytes is recommended)
@@ -70,13 +71,16 @@ public:
 
     void registerOpusFrameAvailableCb(paEncodeInputOpusFrameAvailableCb cb, void *userData);
 
-    int readEncodedOpusFrame(/*int &sequence_number,*/ void *buffer, int buffer_size);
+    //int readUncompressedFrames(/*int &sequence_number,*/ void *buffer, int buffer_size);
+    int encodedOpusFramesAvailable();
+    bool readEncodedOpusFrame(poaCallbackTransferData *data);
 
-    virtual int _HandlePaStreamCallback(const void *inputBuffer,
-                                        void *outputBuffer,
-                                        unsigned long framesPerBuffer,
-                                        const PaStreamCallbackTimeInfo *timeInfo,
-                                        PaStreamCallbackFlags statusFlags) override;
+    virtual int
+    _HandlePaStreamCallback(const void *inputBuffer,
+                            void *outputBuffer,
+                            unsigned long framesPerBuffer,
+                            const PaStreamCallbackTimeInfo *timeInfo,
+                            PaStreamCallbackFlags statusFlags) override;
 };
 
 #endif

--- a/src/poaEncodeInput.h
+++ b/src/poaEncodeInput.h
@@ -8,8 +8,17 @@ class poaEncodeInput : public poaBase
 private:
     /* data */
 public:
+    /** Construct poaEncodeInput.
+     @param @name The name representing this object. This will be used for logging purposes. 
+     */
     poaEncodeInput(const char *name);
     ~poaEncodeInput();
+
+    virtual int HandlePaCallback(const void *inputBuffer,
+                                 void *outputBuffer,
+                                 unsigned long framesPerBuffer,
+                                 const PaStreamCallbackTimeInfo *timeInfo,
+                                 PaStreamCallbackFlags statusFlags);
 };
 
 #endif

--- a/src/poaEncodeInput.h
+++ b/src/poaEncodeInput.h
@@ -23,6 +23,8 @@ public:
 
     void registerOpusFrameAvailableCb(paEncodeInputOpusFrameAvailableCb cb, void *userData);
 
+    int readEncodedOpusFrame(/*int &sequence_number,*/ void *buffer, int buffer_size);
+
     virtual int _HandlePaStreamCallback(const void *inputBuffer,
                                         void *outputBuffer,
                                         unsigned long framesPerBuffer,

--- a/src/rehearse20.cc
+++ b/src/rehearse20.cc
@@ -1,6 +1,7 @@
 #include "rehearse20.h"
 #include "DecodeWorker.h"
 #include "EncodeWorker.h"
+#include "tryout.h"
 
 using namespace Napi;
 
@@ -256,10 +257,20 @@ Napi::Value Rehearse20::InputStopStream(const Napi::CallbackInfo &info)
     return Napi::Number::New(env, err);
 }
 
+Napi::Value Rehearse20::Tryout(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+
+    int result = tryout();
+
+    return Napi::Number::New(env, result);
+}
+
 Napi::Function Rehearse20::GetClass(Napi::Env env)
 {
     return DefineClass(env, "Rehearse20", {
                                               Rehearse20::InstanceMethod("greet", &Rehearse20::Greet),
+                                              Rehearse20::InstanceMethod("tryout", &Rehearse20::Tryout),
                                               Rehearse20::InstanceMethod("detect", &Rehearse20::Detect),
                                               Rehearse20::InstanceMethod("protoring", &Rehearse20::Protoring),
                                               Rehearse20::InstanceMethod("OutputInitAndStartStream", &Rehearse20::OutputInitAndStartStream),

--- a/src/rehearse20.cc
+++ b/src/rehearse20.cc
@@ -1,4 +1,5 @@
 #include "rehearse20.h"
+#include "DecodeWorker.h"
 
 using namespace Napi;
 
@@ -102,9 +103,12 @@ Napi::Value Rehearse20::DecodeDataIntoPlayback(const Napi::CallbackInfo &info)
 
     Buffer<uint8_t> buffer = info[0].As<Buffer<uint8_t>>();
 
-    int result = output.DecodeDataIntoPlayback(buffer.Data(), (int)buffer.Length());
+    // run the actual decoding in a seperate worker
+    // TODO: how to ensure multiple DecodeWorkers don't run into each other (or order gets confused)?
+    DecodeWorker *wk = new DecodeWorker(env, buffer, &output);
+    wk->Queue();
 
-    return Napi::Number::New(env, result);
+    return Napi::Number::New(env, 0);
 }
 
 Napi::Value Rehearse20::InputInitAndStartStream(const Napi::CallbackInfo &info)

--- a/src/rehearse20.cc
+++ b/src/rehearse20.cc
@@ -94,8 +94,11 @@ Napi::Value Rehearse20::OutputInitAndStartStream(const Napi::CallbackInfo &info)
         result = output.StartStream();
     }
 #else
-    output.OpenOutputDeviceStream();
-    output.StartStream();
+    result = output.OpenOutputDeviceStream();
+    if (result == 0)
+    {
+        result = output.StartStream();
+    }
 #endif
 
     return Napi::Number::New(env, result);
@@ -158,8 +161,11 @@ Napi::Value Rehearse20::InputInitAndStartStream(const Napi::CallbackInfo &info)
     }
 #else
     input.registerOpusFrameAvailableCb(paEncodeInStreamOpusFrameAvailableCallback, this);
-    input.OpenInputDeviceStream();
-    input.StartStream();
+    result = input.OpenInputDeviceStream();
+    if (result == 0)
+    {
+        result = input.StartStream();
+    }
 #endif
 
     return Napi::Number::New(env, result);

--- a/src/rehearse20.h
+++ b/src/rehearse20.h
@@ -14,6 +14,7 @@ public:
     static Napi::Function GetClass(Napi::Env);
 
     //PortAudio
+    Napi::Value Tryout(const Napi::CallbackInfo &info);
     Napi::Value Detect(const Napi::CallbackInfo &info);
     Napi::Value Protoring(const Napi::CallbackInfo &info);
 

--- a/src/rehearse20.h
+++ b/src/rehearse20.h
@@ -1,6 +1,5 @@
 #pragma once
 
-
 #include <napi.h>
 #include "paDecodeOutStream.h"
 #include "paEncodeInStream.h"
@@ -23,7 +22,6 @@ public:
     Napi::Value OutputStopStream(const Napi::CallbackInfo &info);
 
     Napi::Value InputInitAndStartStream(const Napi::CallbackInfo &info);
-    Napi::Value EncodeRecordingIntoData(const Napi::CallbackInfo &info);
     Napi::Value InputStopStream(const Napi::CallbackInfo &info);
 
     Napi::Value SetEncodedFrameAvailableCallBack(const Napi::CallbackInfo &info);

--- a/src/rehearse20.h
+++ b/src/rehearse20.h
@@ -1,9 +1,17 @@
 #pragma once
 
 #include <napi.h>
+
+#define USE_OLD_ENCODE_DECODE_STREAM 0
+
+#if USE_OLD_ENCODE_DECODE_STREAM
 #include "paDecodeOutStream.h"
 #include "paEncodeInStream.h"
 #include "paStreamCommon.h"
+#else
+#include "poaEncodeInput.h"
+#include "poaDecodeOutput.h"
+#endif
 
 class Rehearse20 : public Napi::ObjectWrap<Rehearse20>
 {
@@ -33,10 +41,15 @@ public:
 
 private:
     std::string _greeterName;
+#if USE_OLD_ENCODE_DECODE_STREAM
     paDecodeOutStream output;
     paEncodeInStream input;
     int encodeBufferSize;
     uint8_t *encodeBuffer;
+#else
+    poaDecodeOutput output;
+    poaEncodeInput input;
+#endif
 
     bool tsfnSet;
     Napi::ThreadSafeFunction tsfn;

--- a/src/tryout.cpp
+++ b/src/tryout.cpp
@@ -1,6 +1,14 @@
 #include "poaDecodeOutput.h"
 #include "poaEncodeInput.h"
 
+#define LOGERR(r, call)                                              \
+    {                                                                \
+        if (r < 0)                                                   \
+        {                                                            \
+            printf("ERROR: '%s' in %s\n", Pa_GetErrorText(r), call); \
+        }                                                            \
+    }
+
 int tryout()
 {
     poaEncodeInput input("input");
@@ -9,8 +17,13 @@ int tryout()
     input.log("testing %d\n", 1);
     output.log("testing %s\n", "foo");
 
-    input.OpenInputDeviceStream();
-    output.OpenOutputDeviceStream();
+    PaError err;
+
+    err = input.OpenInputDeviceStream(1);
+    LOGERR(err, "input.OpenInputDeviceStream");
+
+    err = output.OpenOutputDeviceStream();
+    LOGERR(err, "output.OpenOutputDeviceStream");
 
     return 0;
 }

--- a/src/tryout.cpp
+++ b/src/tryout.cpp
@@ -43,6 +43,29 @@ public:
         //printf("\nHandleOpusDataTransferCallback::HandleOneOpusFrameAvailable\n");
         cbCount++;
 
+        int available = in->encodedOpusFramesAvailable();
+        if (available < 1)
+        {
+            printf("HandleOneOpusFrameAvailable got trigger, but no frame available??? \n");
+            return;
+        }
+
+        poaCallbackTransferData data;
+        bool read = in->readEncodedOpusFrame(&data);
+        if (!read)
+        {
+            printf("HandleOneOpusFrameAvailable could not readEncodedOpusFrame??\n");
+            return;
+        }
+        printf("HandleOneOpusFrameAvailable sequenceNumber(%d) dataLength(%ld) \n", data.sequenceNumber, data.dataLength);
+
+        bool written = out->writeEncodedOpusFrame(&data);
+        if (!written)
+        {
+            printf("HandleOneOpusFrameAvailable could not writeEncodedOpusFrame??\n");
+        }
+        /*
+
         int read = in->readEncodedOpusFrame(transferBuffer, bufferSize);
         if (read > 0)
         {
@@ -60,7 +83,7 @@ public:
             printf("HandleOneOpusFrameAvailable cbCount: %5d, readBytes: %5d\n",
                    cbCount, read);
         }
-
+*/
         /*
 
         ring_buffer_size_t framesWritten = 0;

--- a/src/tryout.cpp
+++ b/src/tryout.cpp
@@ -1,0 +1,13 @@
+#include "poaDecodeOutput.h"
+#include "poaEncodeInput.h"
+
+int tryout()
+{
+    poaEncodeInput input("input");
+    poaDecodeOutput output("output");
+
+    input.log("testing %d\n", 1);
+    output.log("testing %s\n", "foo");
+
+    return 0;
+}

--- a/src/tryout.cpp
+++ b/src/tryout.cpp
@@ -95,7 +95,7 @@ int tryout()
     printf("output callback running: %d\n", output.IsCallbackRunning());
 #endif
 
-    Pa_Sleep(1000);
+    Pa_Sleep(50);
 
 #if START_INPUT
     printf("input cpu load %2.20f\n", input.GetStreamCpuLoad());

--- a/src/tryout.cpp
+++ b/src/tryout.cpp
@@ -12,6 +12,76 @@
 #define START_INPUT 1
 #define START_OUTPUT 1
 
+class HandleOpusDataTransferCallback
+{
+    // callback handler that is called from paEncodeInstream to notify that an opus frame is available
+    static void callbackHandler(void *userData)
+    {
+        printf("\nHandleOpusDataTransferCallback::callbackHandler\n");
+        HandleOpusDataTransferCallback *p = (HandleOpusDataTransferCallback *)userData;
+        p->HandleOneOpusFrameAvailable();
+    }
+
+public:
+    HandleOpusDataTransferCallback(poaEncodeInput *input, poaDecodeOutput *output)
+    {
+        in = input;
+        out = output; /*
+        bufferSize = in->GetUncompressedBufferSizeBytes();
+        transferBuffer = ALLIGNEDMALLOC(bufferSize);
+        cbCount = 0;
+        cbCountErrors = 0;
+        totalEncodedPacketSize = 0;
+        totalFramesWritten = 0;*/
+
+        // register callback handler
+        in->registerOpusFrameAvailableCb(callbackHandler, this);
+    }
+
+    void HandleOneOpusFrameAvailable()
+    {
+        printf("\nHandleOpusDataTransferCallback::HandleOneOpusFrameAvailable\n");
+
+        /*
+        cbCount++;
+        ring_buffer_size_t framesWritten = 0;
+        int encodedPacketSize = in->EncodeRecordingIntoData(transferBuffer, bufferSize);
+
+        if (encodedPacketSize > 0)
+        {
+            //printf("going to DecodeDataIntoPlayback: %d\n", encodedPacketSize);
+            // decode audio
+            framesWritten = out->DecodeDataIntoPlayback(transferBuffer, encodedPacketSize);
+
+            totalFramesWritten += framesWritten;
+            totalEncodedPacketSize += encodedPacketSize;
+        }
+        else
+        {
+            cbCountErrors++;
+        }
+
+        // this should happen once every second due to 2.5ms frame
+        if (cbCount % 400 == 0)
+        {
+            // error
+            printf("HandleOneOpusFrameAvailable cbCount: %5d, cbErrors: %5d, framesWritten:%5d, encodedSize:%5d \n",
+                   cbCount, cbCountErrors, totalFramesWritten, totalEncodedPacketSize);
+        }*/
+    }
+
+private:
+    poaEncodeInput *in;
+    poaDecodeOutput *out;
+    /*
+    int bufferSize;
+    void *transferBuffer;
+    int cbCount;
+    int cbCountErrors;
+    int totalEncodedPacketSize;
+    int totalFramesWritten; */
+};
+
 int tryout()
 {
 #if START_INPUT
@@ -22,6 +92,9 @@ int tryout()
     poaDecodeOutput output("output");
     output.log("testing %s\n", "foo");
 #endif
+
+    // only works if START_INPUT and START_OUTPUT are defined
+    HandleOpusDataTransferCallback recordingHandler(&input, &output);
 
     PaError err;
 

--- a/src/tryout.cpp
+++ b/src/tryout.cpp
@@ -19,11 +19,52 @@ int tryout()
 
     PaError err;
 
-    err = input.OpenInputDeviceStream(1);
+    err = input.OpenInputDeviceStream();
     LOGERR(err, "input.OpenInputDeviceStream");
 
     err = output.OpenOutputDeviceStream();
     LOGERR(err, "output.OpenOutputDeviceStream");
 
+    printf("input callback running: %d\n", input.IsCallbackRunning());
+    printf("output callback running: %d\n", input.IsCallbackRunning());
+
+    printf("StartStream\n");
+    err = input.StartStream();
+    LOGERR(err, "input.StartStream");
+
+    err = output.StartStream();
+    LOGERR(err, "output.StartStream");
+
+    Pa_Sleep(1000);
+
+    printf("input callback running: %d\n", input.IsCallbackRunning());
+    printf("output callback running: %d\n", input.IsCallbackRunning());
+
+    printf("StopStream\n");
+    err = input.StopStream();
+    LOGERR(err, "input.StopStream");
+
+    err = output.StopStream();
+    LOGERR(err, "output.StopStream");
+
+    printf("input callback running: %d\n", input.IsCallbackRunning());
+    printf("output callback running: %d\n", input.IsCallbackRunning());
+
+    printf("CloseStream\n");
+    err = input.CloseStream();
+    LOGERR(err, "input.CloseStream");
+
+    err = output.CloseStream();
+    LOGERR(err, "output.CloseStream");
+
+    printf("input callback running: %d\n", input.IsCallbackRunning());
+    printf("output callback running: %d\n", input.IsCallbackRunning());
+
+    Pa_Sleep(1000);
+
+    printf("input callback running: %d\n", input.IsCallbackRunning());
+    printf("output callback running: %d\n", input.IsCallbackRunning());
+
+    printf("Exiting...\n");
     return 0;
 }

--- a/src/tryout.cpp
+++ b/src/tryout.cpp
@@ -57,7 +57,7 @@ public:
             printf("HandleOneOpusFrameAvailable could not readEncodedOpusFrame??\n");
             return;
         }
-        printf("HandleOneOpusFrameAvailable sequenceNumber(%d) dataLength(%ld) \n", data.sequenceNumber, data.dataLength);
+        //printf("HandleOneOpusFrameAvailable sequenceNumber(%d) dataLength(%ld) \n", data.sequenceNumber, data.dataLength);
 
         bool written = out->writeEncodedOpusFrame(&data);
         if (!written)

--- a/src/tryout.cpp
+++ b/src/tryout.cpp
@@ -9,65 +9,107 @@
         }                                                            \
     }
 
+#define START_INPUT 1
+#define START_OUTPUT 1
+
 int tryout()
 {
+#if START_INPUT
     poaEncodeInput input("input");
-    poaDecodeOutput output("output");
-
     input.log("testing %d\n", 1);
+#endif
+#if START_OUTPUT
+    poaDecodeOutput output("output");
     output.log("testing %s\n", "foo");
+#endif
 
     PaError err;
 
+#if START_INPUT
     err = input.OpenInputDeviceStream();
     LOGERR(err, "input.OpenInputDeviceStream");
+#endif
 
+#if START_OUTPUT
     err = output.OpenOutputDeviceStream();
     LOGERR(err, "output.OpenOutputDeviceStream");
+#endif
 
+#if START_INPUT
     printf("input callback running: %d\n", input.IsCallbackRunning());
-    printf("output callback running: %d\n", input.IsCallbackRunning());
+#endif
+#if START_OUTPUT
+    printf("output callback running: %d\n", output.IsCallbackRunning());
+#endif
 
     printf("StartStream\n");
+#if START_INPUT
     err = input.StartStream();
     LOGERR(err, "input.StartStream");
-
+#endif
+#if START_OUTPUT
     err = output.StartStream();
     LOGERR(err, "output.StartStream");
+#endif
 
     Pa_Sleep(1000);
 
+#if START_INPUT
     printf("input callback running: %d\n", input.IsCallbackRunning());
-    printf("output callback running: %d\n", input.IsCallbackRunning());
+#endif
+#if START_OUTPUT
+    printf("output callback running: %d\n", output.IsCallbackRunning());
+#endif
 
     printf("StopStream\n");
+#if START_INPUT
     err = input.StopStream();
     LOGERR(err, "input.StopStream");
-
+#endif
+#if START_OUTPUT
     err = output.StopStream();
     LOGERR(err, "output.StopStream");
+#endif
 
+#if START_INPUT
     printf("input callback running: %d\n", input.IsCallbackRunning());
-    printf("output callback running: %d\n", input.IsCallbackRunning());
+#endif
+#if START_OUTPUT
+    printf("output callback running: %d\n", output.IsCallbackRunning());
+#endif
 
     printf("CloseStream\n");
+#if START_INPUT
     err = input.CloseStream();
     LOGERR(err, "input.CloseStream");
-
+#endif
+#if START_OUTPUT
     err = output.CloseStream();
     LOGERR(err, "output.CloseStream");
+#endif
 
+#if START_INPUT
     printf("input callback running: %d\n", input.IsCallbackRunning());
-    printf("output callback running: %d\n", input.IsCallbackRunning());
+#endif
+#if START_OUTPUT
+    printf("output callback running: %d\n", output.IsCallbackRunning());
+#endif
 
     Pa_Sleep(1000);
 
+#if START_INPUT
     printf("input cpu load %2.20f\n", input.GetStreamCpuLoad());
+#endif
+#if START_OUTPUT
     printf("output cpu load %2.20f\n", output.GetStreamCpuLoad());
+#endif
 
+#if START_INPUT
     printf("input callback running: %d\n", input.IsCallbackRunning());
-    printf("output callback running: %d\n", input.IsCallbackRunning());
-
+#endif
+#if START_OUTPUT
+    printf("output callback running: %d\n", output.IsCallbackRunning());
+#endif
     printf("Exiting...\n");
     return 0;
 }

--- a/src/tryout.cpp
+++ b/src/tryout.cpp
@@ -9,5 +9,8 @@ int tryout()
     input.log("testing %d\n", 1);
     output.log("testing %s\n", "foo");
 
+    input.OpenInputDeviceStream();
+    output.OpenOutputDeviceStream();
+
     return 0;
 }

--- a/src/tryout.cpp
+++ b/src/tryout.cpp
@@ -62,6 +62,9 @@ int tryout()
 
     Pa_Sleep(1000);
 
+    printf("input cpu load %2.20f\n", input.GetStreamCpuLoad());
+    printf("output cpu load %2.20f\n", output.GetStreamCpuLoad());
+
     printf("input callback running: %d\n", input.IsCallbackRunning());
     printf("output callback running: %d\n", input.IsCallbackRunning());
 

--- a/src/tryout.h
+++ b/src/tryout.h
@@ -1,0 +1,6 @@
+#ifndef TRYOUT_H
+#define TRYOUT_H
+
+int tryout();
+
+#endif

--- a/test/test_output.ts
+++ b/test/test_output.ts
@@ -1,7 +1,7 @@
 import { PoaExperimental } from '../lib/binding';
 import Rtp = require('./rtp');
 
-const instance = new PoaExperimental("mr-yeoman");
+const instance = new PoaExperimental("local");
 
 import udp = require('dgram');
 

--- a/test/test_rtpoutput.ts
+++ b/test/test_rtpoutput.ts
@@ -1,0 +1,52 @@
+import { PoaExperimental } from '../lib/binding';
+import Rtp = require('./rtp');
+
+import udp = require('dgram');
+
+// creating a udp server
+var server = udp.createSocket('udp4');
+
+// emits when any error occurs
+server.on('error', function (error: string) {
+    console.log('Error: ' + error);
+    server.close();
+});
+
+let rtpClients = new Map<string, PoaExperimental>();
+
+// emits on new datagram msg
+server.on('message', function (msg: Buffer, info: udp.RemoteInfo) {
+    let clientKey = `${info.address}:${info.port}`;
+    let payload = Rtp.payload(msg);
+
+    //console.log(`'${clientKey}' send msg with length ${msg.length}`);
+    if (!rtpClients.has(clientKey)) {
+        console.log(`NEW client detected at: ${clientKey}`);
+        let rtpClient = new PoaExperimental(clientKey);
+        let x = rtpClient.OutputInitAndStartStream();
+        console.log(`OutputInitAndStartStream: ${x}`);
+        rtpClients.set(clientKey, rtpClient);
+    }
+    let currentClient = rtpClients.get(clientKey);
+    if (currentClient) {
+        let status = currentClient.DecodeDataIntoPlayback(payload);
+    }
+});
+
+//emits when socket is ready and listening for datagram msgs
+server.on('listening', function () {
+    var address = server.address();
+    var port = address.port;
+    var family = address.family;
+    var ipaddr = address.address;
+    console.log('Server is listening at port' + port);
+    console.log('Server ip :' + ipaddr);
+    console.log('Server is IP4/IP6 : ' + family);
+});
+
+//emits after the socket is closed using socket.close();
+server.on('close', function () {
+    console.log('Socket is closed !');
+});
+
+server.bind(2222);

--- a/test/tryout.ts
+++ b/test/tryout.ts
@@ -1,0 +1,5 @@
+const PoaExperimental = require("../lib/binding.js").PoaExperimental;
+
+const instance = new PoaExperimental("mr-yeoman");
+
+instance.tryout();


### PR DESCRIPTION
The old implementation performed opus encoding/decoding on the main js thread.
This causes issues when the main node thread cannot keep up for whatever reason.

To get better insight in the latency aspects of this, I refactored the whole internal implementation and introduced poaBase/poaDecodeOutput/poaEncodeInput classes.

Logging was added in case where the audio processing get into unexpected issues so we have a better ability to perform analysis based on meaningful logging.
This can also be used as basis for future work on 'events' related to degraded audio recording/playback.

Some cleanup (removal) of old code still needs to be done, but this is running stable now so better to get it into master for next steps.

