### PR TITLE
switch to node abi prebuilds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,7 @@
     },
     "C_Cpp.default.includePath": [
         ".vscode/napi-include-vscode",
-        "node_modules/node-addon-api"]
+        "node_modules/node-addon-api"
+    ],
+    "cmake.configureOnOpen": true
 }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
         "typescript": "^2.3.3"
     },
     "scripts": {
-        "install": "prebuild-install -t 4 -r napi --verbose || npm run rebuild",
-        "do-prebuild": "prebuild -t 4 -r napi --backend cmake-js",
+        "install": "prebuild-install --verbose || npm run rebuild",
+        "do-prebuild": "prebuild --backend cmake-js -- --CDnapi_build_version=4",
         "prerebuild": "npm run vcpkgupdate",
         "rebuild": "cmake-js rebuild --CDnapi_build_version=4",
         "postrebuild": "tsc",


### PR DESCRIPTION
switch from napi based prebuilds to node abi based rebuilds.
this is in preparation for upcoming prototyping work that is not napi based